### PR TITLE
Fix OpenAPI versioning under FastAPI 0.139+

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,81 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`fast-version` adds Accept-header-based API versioning to FastAPI. Clients select a
+route version via `Accept: <vendor-media-type>; version=<major>.<minor>` (e.g.
+`application/vnd.some.name+json; version=2.0`). Multiple endpoints can share the same
+path+method but differ by version. Public API is just two names exported from
+`fast_version/__init__.py`: `VersionedAPIRouter` and `init_fastapi_versioning`.
+
+## Commands
+
+Uses `uv` and `just`. `uv.lock` is git-ignored here (see `.gitignore`), so it is not
+committed; `just install` regenerates it via `uv lock --upgrade`.
+
+```bash
+just install    # uv lock --upgrade + uv sync --all-extras --all-groups --frozen
+just lint       # ruff format, ruff check --fix, mypy (mutates files)
+just lint-ci    # same checks, no mutation (--check / --no-fix)
+just test       # uv run pytest (coverage is on by default via addopts)
+just            # default recipe: install, lint, test
+```
+
+Run a single test: `just test tests/test_app.py::test_get` or
+`uv run pytest -k test_openapi_schema`.
+
+## Architecture
+
+Versioning is implemented across three layers that cooperate through the ASGI
+`scope["version"]` key:
+
+1. **Middleware parses the Accept header** (`fast_version/app.py`,
+   `FastAPIVersioningMiddleware`). It only acts when the media type before `;`
+   matches the configured `VENDOR_MEDIA_TYPE`; otherwise it passes through
+   untouched (so `*/*`, `application/json`, missing/other media types are ignored,
+   defaulting to v1.0). When it matches, it parses `version=X.Y`, validates against
+   `_VERSION_RE` (`^\d\.\d$`), and writes the parsed tuple into `scope["version"]`.
+   Malformed version key -> 400 "No version in Accept header"; malformed version
+   value -> 400 "Version should be in <major>.<minor> format".
+
+2. **Route matching selects the endpoint by version** (`fast_version/router.py`,
+   `VersionedAPIRoute.matches`). Starlette calls `matches` on each route; this
+   override returns `Match.FULL` only when `scope["version"]` (default `(1, 0)`)
+   equals the route's own version. A path+method with no matching version yields
+   405. Version is stored as a `version` attribute on the endpoint function:
+   `VersionedAPIRouter.api_route` sets `DEFAULT_VERSION` (1, 0) if absent, and the
+   `set_api_version((maj, min))` decorator overrides it. The response's
+   `content-type` is set to the vendor media type + resolved version via a
+   dynamically-generated `VersionedJSONResponse` using the `ClassProperty` descriptor.
+
+3. **OpenAPI schema is rebuilt to avoid version collisions** (`fast_version/app.py`,
+   `_custom_openapi`, monkey-patched onto `app.openapi`). Because multiple routes
+   share a path, it temporarily suffixes each versioned route's `path_format` with
+   `:<version>` so `get_openapi` does not merge them, then splits the suffix back
+   off and merges the per-version schemas under the clean path (via
+   `helpers.dict_merge`), rewriting request/response `content` keys to include
+   `; version=X.Y`.
+
+`init_fastapi_versioning(app=, vendor_media_type=)` wires all three: it sets the
+class-level `VENDOR_MEDIA_TYPE`, adds the middleware, and swaps in `_custom_openapi`.
+
+### Key constraints
+
+- `VENDOR_MEDIA_TYPE` is **class-level state** on `VersionedAPIRouter`, set globally
+  by `init_fastapi_versioning`. There is effectively one vendor media type per process.
+- Version format is strictly single-digit `major.minor` (the regex is `\d\.\d`, not
+  `\d+`). Widening it means changing `_VERSION_RE`.
+- Define versioned endpoints with `VersionedAPIRouter`; the highest/oldest default
+  (no `set_api_version`) is v1.0. Order in tests: the plain route is v1.0, extra
+  versions are stacked with `@ROUTER.set_api_version((maj, min))` above the endpoint.
+
+## Conventions
+
+- Ruff with `select = ["ALL"]` (line length 120), mypy `strict`. Both must pass;
+  CI runs `lint-ci` plus pytest across Python 3.10-3.14 via the shared
+  `community-of-python/community-workflow` reusable workflow.
+- `type: ignore` (not `ty: ignore`) is used here since the type checker is mypy.
+- Tests are ASGI integration tests using `starlette.testclient.TestClient`;
+  `asyncio_mode = "auto"`. Fixtures/endpoints live in `tests/conftest.py`.

--- a/docs/superpowers/plans/2026-07-02-openapi-versioning-fastapi-0139.md
+++ b/docs/superpowers/plans/2026-07-02-openapi-versioning-fastapi-0139.md
@@ -1,0 +1,278 @@
+# OpenAPI Versioning Fix (FastAPI 0.139+) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore correct multi-version OpenAPI schema generation under FastAPI 0.139 / Starlette 1.3.1, where `app.include_router` hides routes inside an opaque `_IncludedRouter` and `get_openapi` no longer honors mutated `path_format`.
+
+**Architecture (revised to Option A during execution):** Adapt the original single-call `_custom_openapi` to FastAPI 0.139. Enumerate routes via `fastapi.routing.iter_route_contexts` (finds routes nested in included routers, with effective prefixed paths), shallow-copy each versioned route with its `path_format` suffixed by `:<version>`, and pass them all through ONE `get_openapi` call. Post-process by splitting the `:<version>` suffix, rewriting request-body media types, and merging per-version paths with `helpers.dict_merge`. A single call is required so FastAPI disambiguates same-named-but-different models across versions — the per-version variant originally drafted here regressed that case (see the fix commit and updated spec).
+
+**Tech Stack:** Python 3.10+, FastAPI 0.139, Starlette 1.3, pytest / pytest-asyncio, ruff (ALL), mypy strict, uv + just.
+
+## Global Constraints
+
+- Python floor: `requires-python = ">=3.10,<4"`; mypy `python_version = 3.10`, ruff `target-version = py310`. Code must run on 3.10.
+- Lint must pass `just lint-ci`: `ruff format --check`, `ruff check --no-fix`, `mypy .` (strict).
+- Type-checker is **mypy**: suppress with `# type: ignore[...]` (not `# ty: ignore`).
+- All function arguments annotated; all imports at module level.
+- Line length 120.
+- `uv.lock` is git-ignored in this repo — never stage it.
+- The `httpx` -> `httpx2` dev-dependency swap in `pyproject.toml` is intentional and kept.
+- Do not change runtime request routing (`FastAPIVersioningMiddleware`, `VersionedAPIRoute.matches`) or widen the `\d\.\d` version format.
+
+---
+
+## Preliminary: branch
+
+- [ ] **Step 0: Create a feature branch** (currently on `main`; never commit the fix to `main`).
+
+```bash
+git checkout -b fix/openapi-versioning-fastapi-0139
+```
+
+---
+
+### Task 1: Per-version OpenAPI schema generation
+
+Replace the broken `_custom_openapi` mechanism. Add a route-enumeration helper that
+finds versioned routes even when nested inside an included router, and rebuild the
+schema per version. This is the core fix.
+
+**Files:**
+- Modify: `fast_version/app.py` (imports; add `_collect_route_contexts`; rewrite `_custom_openapi`)
+- Test: `tests/test_app.py` (add helper test + prefixed-router integration test; existing `test_openapi_schema` already covers the no-prefix case)
+
+**Interfaces:**
+- Produces: `_collect_route_contexts(app: fastapi.FastAPI) -> tuple[list[RouteContext], dict[tuple[int, int], list[RouteContext]]]` — returns `(non_versioned_contexts, versioned_contexts_by_version)`. `RouteContext` is `fastapi.routing.RouteContext`.
+- Produces: `_custom_openapi(self: fastapi.FastAPI) -> dict[str, typing.Any]` — unchanged signature; still bound onto `app.openapi` by `init_fastapi_versioning`.
+- Consumes: `helpers.dict_merge` (existing), `VersionedAPIRoute.version` (existing property returning `tuple[int, int]`).
+
+- [ ] **Step 1: Add the failing tests**
+
+Add these imports at the top of `tests/test_app.py` (below the existing imports):
+
+```python
+import fastapi
+
+from fast_version import init_fastapi_versioning
+from fast_version.app import _collect_route_contexts
+from tests.conftest import VERSIONED_ROUTER_OBJ
+```
+
+Append these two tests to `tests/test_app.py`:
+
+```python
+async def test_collect_route_contexts_finds_versioned_routes_behind_prefix() -> None:
+    app = fastapi.FastAPI()
+    init_fastapi_versioning(app=app, vendor_media_type=VERSION_HEADER)
+    app.include_router(VERSIONED_ROUTER_OBJ, prefix="/api")
+
+    _, versioned = _collect_route_contexts(app)
+
+    assert set(versioned.keys()) == {(1, 0), (2, 0), (1, 1)}
+
+
+async def test_openapi_schema_with_prefix() -> None:
+    amount_of_versions: typing.Final = 2
+
+    app = fastapi.FastAPI()
+    init_fastapi_versioning(app=app, vendor_media_type=VERSION_HEADER)
+    app.include_router(VERSIONED_ROUTER_OBJ, prefix="/api")
+    client = TestClient(app=app)
+
+    response = client.get("/openapi.json")
+    assert response.status_code == status.HTTP_200_OK
+    paths: dict[str, typing.Any] = response.json()["paths"]
+    assert "/api/test/" in paths
+    assert len(paths["/api/test/"]["get"]["responses"]["200"]["content"]) == amount_of_versions
+    assert len(paths["/api/test/"]["post"]["responses"]["200"]["content"]) == amount_of_versions
+    assert len(paths["/api/test/"]["post"]["requestBody"]["content"]) == amount_of_versions
+```
+
+- [ ] **Step 2: Run the new + existing OpenAPI tests to confirm they fail**
+
+Run: `uv run pytest tests/test_app.py -k "openapi or collect_route_contexts" -v`
+Expected: `test_collect_route_contexts_finds_versioned_routes_behind_prefix` FAILS with `ImportError`/`AttributeError` (`_collect_route_contexts` does not exist yet); `test_openapi_schema` and `test_openapi_schema_with_prefix` FAIL on the content-length assertions (`assert 1 == 2`) because versions collapse under FastAPI 0.139.
+
+- [ ] **Step 3: Update imports in `fast_version/app.py`**
+
+Replace the current import block. Remove the now-unused `copy` import and the `starlette.responses.JSONResponse` import is still needed by the middleware — keep it. Add the `fastapi.routing` imports. The full import block becomes:
+
+```python
+import contextlib
+import re
+import typing
+from types import MethodType
+
+import fastapi
+from fastapi.openapi.utils import get_openapi
+from fastapi.routing import RouteContext, iter_route_contexts
+from starlette import types
+from starlette.responses import JSONResponse
+
+from fast_version import helpers
+from fast_version.router import VersionedAPIRoute, VersionedAPIRouter
+```
+
+(Versus the original imports, this drops `import copy` — the old hack used `copy.copy` — and adds the `fastapi.routing` line. After the rewrite, verify `copy` no longer appears anywhere in `app.py`.)
+
+- [ ] **Step 4: Add the `_collect_route_contexts` helper**
+
+Insert this function into `fast_version/app.py` immediately above `_custom_openapi`:
+
+```python
+def _collect_route_contexts(
+    app: fastapi.FastAPI,
+) -> tuple[list[RouteContext], dict[tuple[int, int], list[RouteContext]]]:
+    """Split app routes into non-versioned contexts and versioned contexts grouped by version.
+
+    Traverses nested routers (FastAPI wraps included routers in an opaque object), so
+    routes added via ``app.include_router`` are found and keep their effective paths.
+    """
+    non_versioned: list[RouteContext] = []
+    versioned: dict[tuple[int, int], list[RouteContext]] = {}
+    for route_context in iter_route_contexts(app.routes):
+        original_route = route_context.original_route
+        if isinstance(original_route, VersionedAPIRoute):
+            versioned.setdefault(original_route.version, []).append(route_context)
+        else:
+            non_versioned.append(route_context)
+    return non_versioned, versioned
+```
+
+- [ ] **Step 5: Rewrite `_custom_openapi`**
+
+Replace the entire existing `_custom_openapi` function body with:
+
+```python
+def _custom_openapi(self: fastapi.FastAPI) -> dict[str, typing.Any]:
+    if self.openapi_schema:
+        return self.openapi_schema
+
+    non_versioned, versioned = _collect_route_contexts(self)
+
+    def build(routes: list[RouteContext]) -> dict[str, typing.Any]:
+        return get_openapi(
+            title=self.title,
+            version=self.version,
+            openapi_version=self.openapi_version,
+            summary=self.summary,
+            description=self.description,
+            terms_of_service=self.terms_of_service,
+            contact=self.contact,
+            license_info=self.license_info,
+            routes=routes,
+            webhooks=self.webhooks.routes,
+            tags=self.openapi_tags,
+            servers=self.servers,
+        )
+
+    schema = build(non_versioned)
+    vendor_media_type = _get_vendor_media_type()
+    for version, route_contexts in versioned.items():
+        version_str = ".".join(str(part) for part in version)
+        version_schema = build(route_contexts)
+        for methods in version_schema["paths"].values():
+            for payload in methods.values():
+                if "requestBody" not in payload:
+                    continue
+                payload["requestBody"]["content"] = {
+                    f"{vendor_media_type}; version={version_str}": content
+                    for content in payload["requestBody"]["content"].values()
+                }
+        helpers.dict_merge(schema, version_schema)
+
+    self.openapi_schema = schema
+    return self.openapi_schema
+```
+
+Rationale for each piece:
+- Response `content` keys are already correct per version because `VersionedJSONResponse.media_type` bakes in `; version=X.Y`; only `requestBody` content (default `application/json`) needs rewriting, and it is rewritten only inside per-version schemas (never on the non-versioned base), so non-versioned request bodies are untouched.
+- `helpers.dict_merge` merges paths and components across versions; shared model schemas with identical content merge cleanly.
+- Caching on `self.openapi_schema` preserves the second-call behavior asserted by `test_openapi_schema`.
+
+- [ ] **Step 6: Run the full test suite**
+
+Run: `uv run pytest -q`
+Expected: PASS, `18 passed` (16 existing + 2 new). Coverage on `fast_version/app.py` should be 100%.
+
+- [ ] **Step 7: Run linters**
+
+Run: `uv run ruff format fast_version/app.py tests/test_app.py --check && uv run ruff check fast_version tests --no-fix && uv run mypy .`
+Expected: all pass, `Success: no issues found`. If `ruff format --check` reports a diff, run `uv run ruff format .` and re-run.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add fast_version/app.py tests/test_app.py
+git commit -m "fix: rebuild OpenAPI schema per version for FastAPI 0.139+
+
+include_router now hides routes in an opaque _IncludedRouter and get_openapi
+ignores mutated path_format, collapsing same-path versioned routes. Enumerate
+routes via iter_route_contexts and build one schema per version, then merge."
+```
+
+---
+
+### Task 2: ~~Remove dead `version_str` property~~ — DROPPED
+
+This task is no longer applicable. It assumed the per-version approach (Option 2),
+which stopped using `VersionedAPIRoute.version_str`. The chosen Option A reuses
+`version_str` to build the `:<version>` path suffix, so the property is live and must
+stay. No action.
+
+---
+
+### Task 3: Keep the intended dependency swap
+
+The staged `httpx` -> `httpx2` dev-dependency change is intentional (per user) and
+unrelated to the bug. Commit it separately so history is clean.
+
+**Files:**
+- Modify: `pyproject.toml` (already staged as `M`, line 33: `"httpx"` -> `"httpx2"`)
+
+- [ ] **Step 1: Confirm the diff is only the dev-dependency swap**
+
+Run: `git diff pyproject.toml`
+Expected: single line change under `[dependency-groups].dev`, `- "httpx"` / `+ "httpx2"`. Nothing else.
+
+- [ ] **Step 2: Verify the full CI-equivalent locally**
+
+Run: `uv run ruff format . --check && uv run ruff check . --no-fix && uv run mypy . && uv run pytest -q`
+Expected: all green, `18 passed`. This mirrors `just lint-ci` + `just test`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pyproject.toml
+git commit -m "chore(deps): switch dev dependency httpx -> httpx2"
+```
+
+---
+
+### Task 4: Push and open PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin fix/openapi-versioning-fastapi-0139
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --fill --title "Fix OpenAPI versioning under FastAPI 0.139+"
+```
+
+Include in the body: the root cause (include_router now hides routes in `_IncludedRouter`; `get_openapi` ignores mutated `path_format`), the per-version-merge fix, added prefixed-router coverage, and that the `httpx2` dev-dep swap rides along.
+
+- [ ] **Step 3: Watch CI**
+
+Run: `gh pr checks --watch`
+Expected: the reusable `community-of-python/community-workflow` matrix (Python 3.10-3.14) passes. If a specific Python version fails, reproduce locally with that interpreter before pushing a fix.
+
+---
+
+## Notes / follow-ups (not blocking)
+
+- `CLAUDE.md` (untracked) currently states `uv.lock` is committed here; it is actually git-ignored. Correct that line when `CLAUDE.md` is next touched — out of scope for this branch.
+- The route-enumeration in `_collect_route_contexts` depends on FastAPI internals (`iter_route_contexts` / `RouteContext`). `test_collect_route_contexts_finds_versioned_routes_behind_prefix` is the canary: if a future FastAPI bump breaks enumeration, that test fails loudly and locally.

--- a/docs/superpowers/plans/2026-07-02-openapi-versioning-fastapi-0139.md
+++ b/docs/superpowers/plans/2026-07-02-openapi-versioning-fastapi-0139.md
@@ -41,175 +41,32 @@ schema per version. This is the core fix.
 - Modify: `fast_version/app.py` (imports; add `_collect_route_contexts`; rewrite `_custom_openapi`)
 - Test: `tests/test_app.py` (add helper test + prefixed-router integration test; existing `test_openapi_schema` already covers the no-prefix case)
 
-**Interfaces:**
-- Produces: `_collect_route_contexts(app: fastapi.FastAPI) -> tuple[list[RouteContext], dict[tuple[int, int], list[RouteContext]]]` — returns `(non_versioned_contexts, versioned_contexts_by_version)`. `RouteContext` is `fastapi.routing.RouteContext`.
-- Produces: `_custom_openapi(self: fastapi.FastAPI) -> dict[str, typing.Any]` — unchanged signature; still bound onto `app.openapi` by `init_fastapi_versioning`.
-- Consumes: `helpers.dict_merge` (existing), `VersionedAPIRoute.version` (existing property returning `tuple[int, int]`).
+> **SUPERSEDED — implemented as Option A (single-call).** The step-by-step
+> per-version implementation originally drafted here was rejected during review: one
+> `get_openapi` call per version prevents FastAPI from disambiguating
+> same-named-but-different Pydantic models across versions, silently corrupting such
+> schemas. The shipped implementation (single `get_openapi` call over a flat route
+> list with `:<version>`-suffixed paths) is described below and lives in commits
+> `6d5f68e` (core fix) and `7c2598a` (exact-path-match robustness). See the updated
+> spec for the full rationale.
 
-- [ ] **Step 1: Add the failing tests**
+**Files (as shipped):**
+- Modify: `fast_version/app.py` (imports add `copy`, `fastapi.routing.{RouteContext, iter_route_contexts}`, `starlette.routing.BaseRoute`; add `_iter_openapi_routes`; rewrite `_custom_openapi`).
+- Test: `tests/test_app.py` (four new tests, see below).
 
-Add these imports at the top of `tests/test_app.py` (below the existing imports):
+**Interfaces (as shipped):**
+- `_iter_openapi_routes(app: fastapi.FastAPI) -> tuple[list[BaseRoute | RouteContext], set[str]]` — returns `(routes, versioned_suffixed_paths)`. Non-versioned routes pass through as `RouteContext`; each versioned route is a `copy.copy` with `path_format` set to `f"{route_context.path_format}:{original_route.version_str}"`. The returned set holds those suffixed paths for exact-match identification during post-processing.
+- `_custom_openapi(self: fastapi.FastAPI) -> dict[str, typing.Any]` — unchanged signature; still bound onto `app.openapi` by `init_fastapi_versioning`. Makes ONE `get_openapi` call over `_iter_openapi_routes(self)[0]`, then for each generated path in the versioned-paths set: `rsplit(":", 1)` into `clean_path` + `version_str`, rewrite `requestBody.content` keys to `<vendor>; version=X.Y`, and merge onto `clean_path` (first occurrence direct, later via `helpers.dict_merge`). Non-versioned paths pass through untouched. Caches on `self.openapi_schema`.
+- Consumes: `helpers.dict_merge`, `VersionedAPIRoute.version`/`version_str` (both stay).
 
-```python
-import fastapi
+**Tests (as shipped):**
+- Existing `test_openapi_schema` (no-prefix, both versions in get/post response + post requestBody) — still passes.
+- `test_iter_openapi_routes_finds_prefixed_versioned_paths` — with `prefix="/api"`, the returned set and the copies' `path_format`s are `{"/api/test/:1.0", "/api/test/:2.0", "/api/test/:1.1"}`.
+- `test_openapi_schema_with_prefix` — prefixed router exposes both versions at `/api/test/`.
+- `test_openapi_schema_distinct_models_with_shared_name_across_versions` — regression guard for the single-call requirement (distinct `$ref`s + correct per-version properties for two same-named models).
+- `test_openapi_schema_preserves_non_versioned_path_with_colon` — a non-versioned `/resource:activate` keeps its `application/json` body (colon not mistaken for a version suffix).
 
-from fast_version import init_fastapi_versioning
-from fast_version.app import _collect_route_contexts
-from tests.conftest import VERSIONED_ROUTER_OBJ
-```
-
-Append these two tests to `tests/test_app.py`:
-
-```python
-async def test_collect_route_contexts_finds_versioned_routes_behind_prefix() -> None:
-    app = fastapi.FastAPI()
-    init_fastapi_versioning(app=app, vendor_media_type=VERSION_HEADER)
-    app.include_router(VERSIONED_ROUTER_OBJ, prefix="/api")
-
-    _, versioned = _collect_route_contexts(app)
-
-    assert set(versioned.keys()) == {(1, 0), (2, 0), (1, 1)}
-
-
-async def test_openapi_schema_with_prefix() -> None:
-    amount_of_versions: typing.Final = 2
-
-    app = fastapi.FastAPI()
-    init_fastapi_versioning(app=app, vendor_media_type=VERSION_HEADER)
-    app.include_router(VERSIONED_ROUTER_OBJ, prefix="/api")
-    client = TestClient(app=app)
-
-    response = client.get("/openapi.json")
-    assert response.status_code == status.HTTP_200_OK
-    paths: dict[str, typing.Any] = response.json()["paths"]
-    assert "/api/test/" in paths
-    assert len(paths["/api/test/"]["get"]["responses"]["200"]["content"]) == amount_of_versions
-    assert len(paths["/api/test/"]["post"]["responses"]["200"]["content"]) == amount_of_versions
-    assert len(paths["/api/test/"]["post"]["requestBody"]["content"]) == amount_of_versions
-```
-
-- [ ] **Step 2: Run the new + existing OpenAPI tests to confirm they fail**
-
-Run: `uv run pytest tests/test_app.py -k "openapi or collect_route_contexts" -v`
-Expected: `test_collect_route_contexts_finds_versioned_routes_behind_prefix` FAILS with `ImportError`/`AttributeError` (`_collect_route_contexts` does not exist yet); `test_openapi_schema` and `test_openapi_schema_with_prefix` FAIL on the content-length assertions (`assert 1 == 2`) because versions collapse under FastAPI 0.139.
-
-- [ ] **Step 3: Update imports in `fast_version/app.py`**
-
-Replace the current import block. Remove the now-unused `copy` import and the `starlette.responses.JSONResponse` import is still needed by the middleware — keep it. Add the `fastapi.routing` imports. The full import block becomes:
-
-```python
-import contextlib
-import re
-import typing
-from types import MethodType
-
-import fastapi
-from fastapi.openapi.utils import get_openapi
-from fastapi.routing import RouteContext, iter_route_contexts
-from starlette import types
-from starlette.responses import JSONResponse
-
-from fast_version import helpers
-from fast_version.router import VersionedAPIRoute, VersionedAPIRouter
-```
-
-(Versus the original imports, this drops `import copy` — the old hack used `copy.copy` — and adds the `fastapi.routing` line. After the rewrite, verify `copy` no longer appears anywhere in `app.py`.)
-
-- [ ] **Step 4: Add the `_collect_route_contexts` helper**
-
-Insert this function into `fast_version/app.py` immediately above `_custom_openapi`:
-
-```python
-def _collect_route_contexts(
-    app: fastapi.FastAPI,
-) -> tuple[list[RouteContext], dict[tuple[int, int], list[RouteContext]]]:
-    """Split app routes into non-versioned contexts and versioned contexts grouped by version.
-
-    Traverses nested routers (FastAPI wraps included routers in an opaque object), so
-    routes added via ``app.include_router`` are found and keep their effective paths.
-    """
-    non_versioned: list[RouteContext] = []
-    versioned: dict[tuple[int, int], list[RouteContext]] = {}
-    for route_context in iter_route_contexts(app.routes):
-        original_route = route_context.original_route
-        if isinstance(original_route, VersionedAPIRoute):
-            versioned.setdefault(original_route.version, []).append(route_context)
-        else:
-            non_versioned.append(route_context)
-    return non_versioned, versioned
-```
-
-- [ ] **Step 5: Rewrite `_custom_openapi`**
-
-Replace the entire existing `_custom_openapi` function body with:
-
-```python
-def _custom_openapi(self: fastapi.FastAPI) -> dict[str, typing.Any]:
-    if self.openapi_schema:
-        return self.openapi_schema
-
-    non_versioned, versioned = _collect_route_contexts(self)
-
-    def build(routes: list[RouteContext]) -> dict[str, typing.Any]:
-        return get_openapi(
-            title=self.title,
-            version=self.version,
-            openapi_version=self.openapi_version,
-            summary=self.summary,
-            description=self.description,
-            terms_of_service=self.terms_of_service,
-            contact=self.contact,
-            license_info=self.license_info,
-            routes=routes,
-            webhooks=self.webhooks.routes,
-            tags=self.openapi_tags,
-            servers=self.servers,
-        )
-
-    schema = build(non_versioned)
-    vendor_media_type = _get_vendor_media_type()
-    for version, route_contexts in versioned.items():
-        version_str = ".".join(str(part) for part in version)
-        version_schema = build(route_contexts)
-        for methods in version_schema["paths"].values():
-            for payload in methods.values():
-                if "requestBody" not in payload:
-                    continue
-                payload["requestBody"]["content"] = {
-                    f"{vendor_media_type}; version={version_str}": content
-                    for content in payload["requestBody"]["content"].values()
-                }
-        helpers.dict_merge(schema, version_schema)
-
-    self.openapi_schema = schema
-    return self.openapi_schema
-```
-
-Rationale for each piece:
-- Response `content` keys are already correct per version because `VersionedJSONResponse.media_type` bakes in `; version=X.Y`; only `requestBody` content (default `application/json`) needs rewriting, and it is rewritten only inside per-version schemas (never on the non-versioned base), so non-versioned request bodies are untouched.
-- `helpers.dict_merge` merges paths and components across versions; shared model schemas with identical content merge cleanly.
-- Caching on `self.openapi_schema` preserves the second-call behavior asserted by `test_openapi_schema`.
-
-- [ ] **Step 6: Run the full test suite**
-
-Run: `uv run pytest -q`
-Expected: PASS, `18 passed` (16 existing + 2 new). Coverage on `fast_version/app.py` should be 100%.
-
-- [ ] **Step 7: Run linters**
-
-Run: `uv run ruff format fast_version/app.py tests/test_app.py --check && uv run ruff check fast_version tests --no-fix && uv run mypy .`
-Expected: all pass, `Success: no issues found`. If `ruff format --check` reports a diff, run `uv run ruff format .` and re-run.
-
-- [ ] **Step 8: Commit**
-
-```bash
-git add fast_version/app.py tests/test_app.py
-git commit -m "fix: rebuild OpenAPI schema per version for FastAPI 0.139+
-
-include_router now hides routes in an opaque _IncludedRouter and get_openapi
-ignores mutated path_format, collapsing same-path versioned routes. Enumerate
-routes via iter_route_contexts and build one schema per version, then merge."
-```
+**TDD note:** the existing `test_openapi_schema` was already RED under FastAPI 0.139; the model and colon regression tests were confirmed RED against the pre-fix code before implementing. Final state: 20 passed, ruff/mypy strict clean, 100% coverage on `app.py` and `router.py`.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-01-openapi-versioning-fastapi-0139-design.md
+++ b/docs/superpowers/specs/2026-07-01-openapi-versioning-fastapi-0139-design.md
@@ -32,33 +32,47 @@ FastAPI 0.139 breaks steps 1 and 2:
   **not** propagate to what `get_openapi` reads. The copy-and-mutate mechanism is
   structurally dead, not one-line-fixable.
 
-## Approach (chosen: per-version schema merge)
+## Approach (chosen: single-call, flat route list with version-suffixed paths)
 
-Stop tricking `get_openapi` into not merging. Instead, generate a clean schema per
-version and merge the results:
+> **Decision history.** An earlier draft chose a per-version approach (one
+> `get_openapi` call per version group, then merge). During implementation review it
+> was found to regress a real case (see "Why single-call" below), and the design was
+> changed to the single-call approach documented here.
 
-1. **Enumerate versioned routes.** Collect all `VersionedAPIRoute` instances the app
-   serves, including those nested inside `_IncludedRouter` (and any nested routers),
-   with their effective paths. This route-enumeration is the one unavoidable
-   FastAPI-internal dependency; both candidate approaches share it.
-2. **Group routes by version** (the `route.version` tuple).
-3. **Call `get_openapi` once per version group**, passing only that version's
-   `VersionedAPIRoute`s plus all non-versioned routes, via the public `routes=`
-   parameter. No two routes in a group share path+method, so nothing collides and no
-   `path_format` mutation or `:`-suffix string surgery is needed.
-4. **Merge the per-version schemas** into a single schema with `helpers.dict_merge`.
-   Response `content` keys are already correct per version because
-   `VersionedJSONResponse.media_type` bakes in `; version=X.Y`. Request-body `content`
-   keys still need the existing rewrite to `<vendor>; version=X.Y`.
-5. Cache the result on `self.openapi_schema` as before.
+Adapt the original `_custom_openapi` mechanism to FastAPI 0.139's route model:
 
-### Why this over "restore the mechanism"
+1. **Enumerate routes with effective paths.** Iterate
+   `fastapi.routing.iter_route_contexts(app.routes)`. This sees `VersionedAPIRoute`s
+   nested inside included routers (`_IncludedRouter`) and exposes each route's
+   effective `path_format` (prefix included). This route-enumeration is the one
+   unavoidable FastAPI-internal dependency.
+2. **Build a flat route list for a single call.** Non-versioned contexts pass through
+   unchanged. Each versioned route is shallow-copied with
+   `path_format = f"{context.path_format}:{route.version_str}"` so `get_openapi` keeps
+   same-path versions distinct. Because the copies are passed directly (not through an
+   included router), `get_openapi` reads `path_format` from the copy, so the suffix
+   takes effect.
+3. **One `get_openapi` call** over that list.
+4. **Post-process paths.** For each generated path: no `:` -> keep as-is; otherwise
+   `rsplit(":", 1)` into `clean_path` + `version_str`, rewrite each operation's
+   `requestBody.content` keys to `<vendor>; version=X.Y`, and merge into `clean_path`
+   (`helpers.dict_merge` for later occurrences). Response `content` keys are already
+   correct because `VersionedJSONResponse.media_type` bakes in `; version=X.Y`.
+5. Cache on `self.openapi_schema` as before.
 
-The alternative (traverse `_IncludedRouter`, copy routes, re-suffix `path_format`,
-pass a flat list) rebuilds on the exact internal path-computation layer that just
-broke, plus fragile `:`-splitting. Option 2 depends only on `get_openapi`'s public
-`routes=` param; the sole internal dependency (route enumeration) is shared by both.
-Fewer fragile assumptions -> more durable across future FastAPI refactors.
+### Why single-call (not per-version merge)
+
+FastAPI disambiguates same-named-but-different Pydantic models **only within one
+`get_openapi` call**. If two versions define different models sharing a class name
+(e.g. an `Item` that gains a `price` field in v2, defined in separate `v1/`/`v2/`
+modules — a normal versioning pattern), a single call emits two distinct component
+schemas with correct per-version `$ref`s. Splitting into one call per version makes
+each call see only its own models, so both versions `$ref` the same
+`#/components/schemas/Item` and the merge silently corrupts the older version. The
+single-call property of the original design was load-bearing for correctness; this
+approach preserves it. Cost: it reuses the `path_format`-suffix + `:`-split mechanism,
+which is FastAPI-internal but fails visibly (a stray `:` in a path) rather than
+silently, and is guarded by a regression test.
 
 ## Testing (TDD)
 
@@ -71,6 +85,10 @@ Write the failing test first, then implement.
 - **New coverage:** a versioned router included with a `prefix=` must still produce a
   correctly versioned, merged schema at the prefixed path. Current tests do not cover
   prefixes, and route-enumeration through `_IncludedRouter` is the risky part.
+- **New coverage (regression guard):** two versions of one POST route whose body
+  models share a class name but differ in fields must produce distinct component
+  schemas and distinct per-version `$ref`s. This test fails on the per-version
+  approach and passes on the single-call approach.
 - Non-versioned routes (`/simple/`, websocket) remain untouched in the schema.
 - All existing tests continue to pass under FastAPI 0.139 / Starlette 1.3.1.
 
@@ -82,6 +100,8 @@ Write the failing test first, then implement.
 
 ## Risks
 
-- Route enumeration relies on FastAPI/Starlette internals (`_IncludedRouter` and its
-  route-context accessors). Mitigation: isolate this traversal in one small helper
-  with a focused test, so a future break is localized and obvious.
+- Route enumeration and the `path_format`-suffix trick rely on FastAPI/Starlette
+  internals (`iter_route_contexts`, `RouteContext.path_format`, and `get_openapi`
+  keying paths off `path_format`). Mitigation: isolate the traversal in one small
+  helper (`_iter_openapi_routes`) with a focused test asserting the effective
+  version-suffixed paths, so a future break is localized and fails loudly.

--- a/docs/superpowers/specs/2026-07-01-openapi-versioning-fastapi-0139-design.md
+++ b/docs/superpowers/specs/2026-07-01-openapi-versioning-fastapi-0139-design.md
@@ -1,0 +1,87 @@
+# Fix OpenAPI version schema generation for FastAPI 0.139+
+
+Date: 2026-07-01
+
+## Problem
+
+`test_openapi_schema` fails after a dependency upgrade. `GET /test/` in the
+generated OpenAPI schema contains only `version=2.0` in its `responses.200.content`
+instead of both `1.0` and `2.0`. Runtime version routing is unaffected (all other
+tests pass); only schema generation is broken.
+
+### Root cause
+
+The staged `httpx` -> `httpx2` change is unrelated (test-only dependency). The real
+trigger is `uv lock --upgrade` (run by `just install`) bumping **FastAPI to 0.139.0 /
+Starlette 1.3.1**, which shipped a routing/OpenAPI refactor.
+
+`_custom_openapi` (`fast_version/app.py`) worked by:
+1. Iterating `self.routes`, finding `VersionedAPIRoute` instances.
+2. Shallow-copying each and suffixing `path_format` with `:<version>` so
+   `get_openapi` would not merge same-path routes.
+3. Splitting the `:<version>` suffix back off and merging per-version schemas with
+   `helpers.dict_merge`, rewriting request-body `content` keys to include
+   `; version=X.Y`.
+
+FastAPI 0.139 breaks steps 1 and 2:
+- `app.include_router(R)` no longer flattens routes into `app.routes`; it stores a
+  single opaque `_IncludedRouter`. `self.routes` contains **zero** `VersionedAPIRoute`
+  instances, so nothing gets suffixed.
+- `get_openapi` now reads `path_format` off a `RouteContext` computed through an
+  effective-route-context layer. Verified: mutating `original_route.path_format` does
+  **not** propagate to what `get_openapi` reads. The copy-and-mutate mechanism is
+  structurally dead, not one-line-fixable.
+
+## Approach (chosen: per-version schema merge)
+
+Stop tricking `get_openapi` into not merging. Instead, generate a clean schema per
+version and merge the results:
+
+1. **Enumerate versioned routes.** Collect all `VersionedAPIRoute` instances the app
+   serves, including those nested inside `_IncludedRouter` (and any nested routers),
+   with their effective paths. This route-enumeration is the one unavoidable
+   FastAPI-internal dependency; both candidate approaches share it.
+2. **Group routes by version** (the `route.version` tuple).
+3. **Call `get_openapi` once per version group**, passing only that version's
+   `VersionedAPIRoute`s plus all non-versioned routes, via the public `routes=`
+   parameter. No two routes in a group share path+method, so nothing collides and no
+   `path_format` mutation or `:`-suffix string surgery is needed.
+4. **Merge the per-version schemas** into a single schema with `helpers.dict_merge`.
+   Response `content` keys are already correct per version because
+   `VersionedJSONResponse.media_type` bakes in `; version=X.Y`. Request-body `content`
+   keys still need the existing rewrite to `<vendor>; version=X.Y`.
+5. Cache the result on `self.openapi_schema` as before.
+
+### Why this over "restore the mechanism"
+
+The alternative (traverse `_IncludedRouter`, copy routes, re-suffix `path_format`,
+pass a flat list) rebuilds on the exact internal path-computation layer that just
+broke, plus fragile `:`-splitting. Option 2 depends only on `get_openapi`'s public
+`routes=` param; the sole internal dependency (route enumeration) is shared by both.
+Fewer fragile assumptions -> more durable across future FastAPI refactors.
+
+## Testing (TDD)
+
+Write the failing test first, then implement.
+
+- Extend/confirm `test_openapi_schema`: `GET /test/` and `POST /test/` each expose
+  both versions in `responses.200.content`; `POST /test/` request body exposes both
+  versions in `requestBody.content`; total path count is correct; second call returns
+  the cached schema.
+- **New coverage:** a versioned router included with a `prefix=` must still produce a
+  correctly versioned, merged schema at the prefixed path. Current tests do not cover
+  prefixes, and route-enumeration through `_IncludedRouter` is the risky part.
+- Non-versioned routes (`/simple/`, websocket) remain untouched in the schema.
+- All existing tests continue to pass under FastAPI 0.139 / Starlette 1.3.1.
+
+## Out of scope
+
+- The `httpx` -> `httpx2` dev-dependency swap is intentional and kept as-is.
+- No change to runtime request routing (middleware, `VersionedAPIRoute.matches`).
+- No widening of the `\d\.\d` version format.
+
+## Risks
+
+- Route enumeration relies on FastAPI/Starlette internals (`_IncludedRouter` and its
+  route-context accessors). Mitigation: isolate this traversal in one small helper
+  with a focused test, so a future break is localized and obvious.

--- a/fast_version/app.py
+++ b/fast_version/app.py
@@ -83,7 +83,9 @@ class FastAPIVersioningMiddleware:
         return await self.app(scope, receive, send)
 
 
-def _iter_openapi_routes(app: fastapi.FastAPI) -> list[BaseRoute | RouteContext]:
+def _iter_openapi_routes(
+    app: fastapi.FastAPI,
+) -> tuple[list[BaseRoute | RouteContext], set[str]]:
     """Build the route list for a single ``get_openapi`` call.
 
     Traverses nested routers (FastAPI wraps included routers in an opaque object), so
@@ -92,23 +94,31 @@ def _iter_openapi_routes(app: fastapi.FastAPI) -> list[BaseRoute | RouteContext]
     with its ``path_format`` suffixed by ``:<version>`` so ``get_openapi`` keeps
     same-path versions distinct within one call. A single call is required so FastAPI
     disambiguates same-named-but-different Pydantic models across versions.
+
+    Returns the route list plus the set of suffixed paths it produced, so schema
+    post-processing can identify versioned paths by exact match rather than by sniffing
+    for a colon (a non-versioned path may legitimately contain one, e.g. ``/x:action``).
     """
     routes: list[BaseRoute | RouteContext] = []
+    versioned_paths: set[str] = set()
     for route_context in iter_route_contexts(app.routes):
         original_route = route_context.original_route
         if not isinstance(original_route, VersionedAPIRoute):
             routes.append(route_context)
             continue
+        suffixed_path = f"{route_context.path_format}:{original_route.version_str}"
         route_copy = copy.copy(original_route)
-        route_copy.path_format = f"{route_context.path_format}:{original_route.version_str}"
+        route_copy.path_format = suffixed_path
         routes.append(route_copy)
-    return routes
+        versioned_paths.add(suffixed_path)
+    return routes, versioned_paths
 
 
 def _custom_openapi(self: fastapi.FastAPI) -> dict[str, typing.Any]:
     if self.openapi_schema:
         return self.openapi_schema
 
+    routes, versioned_paths = _iter_openapi_routes(self)
     self.openapi_schema = get_openapi(
         title=self.title,
         version=self.version,
@@ -118,18 +128,22 @@ def _custom_openapi(self: fastapi.FastAPI) -> dict[str, typing.Any]:
         terms_of_service=self.terms_of_service,
         contact=self.contact,
         license_info=self.license_info,
-        routes=_iter_openapi_routes(self),
+        routes=routes,
         webhooks=self.webhooks.routes,
         tags=self.openapi_tags,
         servers=self.servers,
     )
 
+    # Collapse the per-version paths back onto their real path. Only the request/response
+    # bodies are versioned (keyed by media type); operation-level fields (parameters,
+    # summary, tags, ...) are taken from the first-merged version, so versions of the same
+    # path+method should differ only in body schema.
     vendor_media_type = _get_vendor_media_type()
     paths_dict: dict[str, typing.Any] = {}
     raw_path: str
     methods: dict[str, typing.Any]
     for raw_path, methods in self.openapi_schema["paths"].items():
-        if ":" not in raw_path:
+        if raw_path not in versioned_paths:
             paths_dict[raw_path] = methods
             continue
         clean_path, version_str = raw_path.rsplit(":", 1)

--- a/fast_version/app.py
+++ b/fast_version/app.py
@@ -6,8 +6,10 @@ from types import MethodType
 
 import fastapi
 from fastapi.openapi.utils import get_openapi
+from fastapi.routing import RouteContext, iter_route_contexts
 from starlette import types
 from starlette.responses import JSONResponse
+from starlette.routing import BaseRoute
 
 from fast_version import helpers
 from fast_version.router import VersionedAPIRoute, VersionedAPIRouter
@@ -81,20 +83,31 @@ class FastAPIVersioningMiddleware:
         return await self.app(scope, receive, send)
 
 
+def _iter_openapi_routes(app: fastapi.FastAPI) -> list[BaseRoute | RouteContext]:
+    """Build the route list for a single ``get_openapi`` call.
+
+    Traverses nested routers (FastAPI wraps included routers in an opaque object), so
+    routes added via ``app.include_router`` are found and keep their effective paths.
+    Non-versioned routes pass through unchanged; each versioned route is shallow-copied
+    with its ``path_format`` suffixed by ``:<version>`` so ``get_openapi`` keeps
+    same-path versions distinct within one call. A single call is required so FastAPI
+    disambiguates same-named-but-different Pydantic models across versions.
+    """
+    routes: list[BaseRoute | RouteContext] = []
+    for route_context in iter_route_contexts(app.routes):
+        original_route = route_context.original_route
+        if not isinstance(original_route, VersionedAPIRoute):
+            routes.append(route_context)
+            continue
+        route_copy = copy.copy(original_route)
+        route_copy.path_format = f"{route_context.path_format}:{original_route.version_str}"
+        routes.append(route_copy)
+    return routes
+
+
 def _custom_openapi(self: fastapi.FastAPI) -> dict[str, typing.Any]:
     if self.openapi_schema:
         return self.openapi_schema
-
-    routes = []
-    for route_item in self.routes:
-        if not isinstance(route_item, VersionedAPIRoute):
-            routes.append(route_item)
-            continue
-
-        # trick to avoid merging routes
-        route_copy = copy.copy(route_item)
-        route_copy.path_format = f"{route_copy.path_format}:{route_copy.version_str}"
-        routes.append(route_copy)
 
     self.openapi_schema = get_openapi(
         title=self.title,
@@ -105,31 +118,31 @@ def _custom_openapi(self: fastapi.FastAPI) -> dict[str, typing.Any]:
         terms_of_service=self.terms_of_service,
         contact=self.contact,
         license_info=self.license_info,
-        routes=routes,
+        routes=_iter_openapi_routes(self),
         webhooks=self.webhooks.routes,
         tags=self.openapi_tags,
         servers=self.servers,
     )
-    paths_dict = {}
+
+    vendor_media_type = _get_vendor_media_type()
+    paths_dict: dict[str, typing.Any] = {}
     raw_path: str
     methods: dict[str, typing.Any]
     for raw_path, methods in self.openapi_schema["paths"].items():
         if ":" not in raw_path:
             paths_dict[raw_path] = methods
             continue
-        clean_path, version = raw_path.split(":")
+        clean_path, version_str = raw_path.rsplit(":", 1)
         for payload in methods.values():
             if "requestBody" not in payload:
                 continue
             payload["requestBody"]["content"] = {
-                f"{_get_vendor_media_type()}; version={version}": v
-                for k, v in payload["requestBody"]["content"].items()
+                f"{vendor_media_type}; version={version_str}": content
+                for content in payload["requestBody"]["content"].values()
             }
-
         if clean_path not in paths_dict:
             paths_dict[clean_path] = methods
             continue
-
         helpers.dict_merge(paths_dict[clean_path], methods)
     self.openapi_schema["paths"] = paths_dict
     return self.openapi_schema

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ repository = "https://github.com/community-of-python/fast-version"
 
 [dependency-groups]
 dev = [
-    "httpx",
+    "httpx2",
     "pytest",
     "pytest-cov",
     "pytest-asyncio",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -208,6 +208,16 @@ async def test_openapi_schema_distinct_models_with_shared_name_across_versions()
     assert set(schemas[v1_ref.rsplit("/", 1)[-1]]["properties"]) == {"name"}
     assert set(schemas[v2_ref.rsplit("/", 1)[-1]]["properties"]) == {"name", "price"}
 
+    # Each version routes to its own endpoint at runtime with its own body model.
+    v1_response = client.post("/thing/", json={"name": "x"}, headers={"Accept": f"{VERSION_HEADER}; version=1.0"})
+    assert v1_response.status_code == status.HTTP_200_OK
+    v2_response = client.post(
+        "/thing/",
+        json={"name": "x", "price": 1.0},
+        headers={"Accept": f"{VERSION_HEADER}; version=2.0"},
+    )
+    assert v2_response.status_code == status.HTTP_200_OK
+
 
 async def test_openapi_schema_preserves_non_versioned_path_with_colon() -> None:
     # A non-versioned path may legitimately contain a colon (custom-method REST style).
@@ -230,3 +240,6 @@ async def test_openapi_schema_preserves_non_versioned_path_with_colon() -> None:
     assert "/resource:activate" in schema["paths"]
     content = schema["paths"]["/resource:activate"]["post"]["requestBody"]["content"]
     assert set(content.keys()) == {"application/json"}
+
+    response = client.post("/resource:activate", json={"value": "x"})
+    assert response.status_code == status.HTTP_200_OK

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,10 +1,15 @@
 import typing
 
+import fastapi
+import pydantic
 import pytest
 from starlette import status
 from starlette.testclient import TestClient
 
-from tests.conftest import DOCS_URL_PREFIX, VERSION_HEADER
+from fast_version import init_fastapi_versioning
+from fast_version.app import _iter_openapi_routes
+from fast_version.router import VersionedAPIRoute, VersionedAPIRouter
+from tests.conftest import DOCS_URL_PREFIX, VERSION_HEADER, VERSIONED_ROUTER_OBJ
 
 
 pytestmark = [pytest.mark.asyncio]
@@ -140,3 +145,64 @@ async def test_openapi_schema(test_client: TestClient) -> None:
 
     response = test_client.get("/openapi.json")
     assert response.status_code == status.HTTP_200_OK
+
+
+async def test_iter_openapi_routes_finds_prefixed_versioned_paths() -> None:
+    app = fastapi.FastAPI()
+    init_fastapi_versioning(app=app, vendor_media_type=VERSION_HEADER)
+    app.include_router(VERSIONED_ROUTER_OBJ, prefix="/api")
+
+    routes = _iter_openapi_routes(app)
+
+    versioned_paths = {route.path_format for route in routes if isinstance(route, VersionedAPIRoute)}
+    assert versioned_paths == {"/api/test/:1.0", "/api/test/:2.0", "/api/test/:1.1"}
+
+
+async def test_openapi_schema_with_prefix() -> None:
+    amount_of_versions: typing.Final = 2
+
+    app = fastapi.FastAPI()
+    init_fastapi_versioning(app=app, vendor_media_type=VERSION_HEADER)
+    app.include_router(VERSIONED_ROUTER_OBJ, prefix="/api")
+    client = TestClient(app=app)
+
+    response = client.get("/openapi.json")
+    assert response.status_code == status.HTTP_200_OK
+    paths: dict[str, typing.Any] = response.json()["paths"]
+    assert "/api/test/" in paths
+    assert len(paths["/api/test/"]["get"]["responses"]["200"]["content"]) == amount_of_versions
+    assert len(paths["/api/test/"]["post"]["responses"]["200"]["content"]) == amount_of_versions
+    assert len(paths["/api/test/"]["post"]["requestBody"]["content"]) == amount_of_versions
+
+
+async def test_openapi_schema_distinct_models_with_shared_name_across_versions() -> None:
+    # Two different models sharing a class name (as if defined in separate v1/v2 modules).
+    # A single get_openapi call must disambiguate them; a per-version merge would collapse
+    # both request bodies onto one component schema and silently corrupt v1.0.
+    item_v1 = pydantic.create_model("Item", name=(str, ...))
+    item_v2 = pydantic.create_model("Item", name=(str, ...), price=(float, ...))
+    router = VersionedAPIRouter()
+
+    @router.post("/thing/")
+    async def _create(_: item_v1) -> dict[str, typing.Any]:  # type: ignore[valid-type]
+        return {}
+
+    @router.post("/thing/")
+    @router.set_api_version((2, 0))
+    async def _create_v2(_: item_v2) -> dict[str, typing.Any]:  # type: ignore[valid-type]
+        return {}
+
+    app = fastapi.FastAPI()
+    init_fastapi_versioning(app=app, vendor_media_type=VERSION_HEADER)
+    app.include_router(router)
+    client = TestClient(app=app)
+
+    schema = client.get("/openapi.json").json()
+    content = schema["paths"]["/thing/"]["post"]["requestBody"]["content"]
+    v1_ref = content[f"{VERSION_HEADER}; version=1.0"]["schema"]["$ref"]
+    v2_ref = content[f"{VERSION_HEADER}; version=2.0"]["schema"]["$ref"]
+    assert v1_ref != v2_ref
+
+    schemas = schema["components"]["schemas"]
+    assert set(schemas[v1_ref.rsplit("/", 1)[-1]]["properties"]) == {"name"}
+    assert set(schemas[v2_ref.rsplit("/", 1)[-1]]["properties"]) == {"name", "price"}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -152,10 +152,11 @@ async def test_iter_openapi_routes_finds_prefixed_versioned_paths() -> None:
     init_fastapi_versioning(app=app, vendor_media_type=VERSION_HEADER)
     app.include_router(VERSIONED_ROUTER_OBJ, prefix="/api")
 
-    routes = _iter_openapi_routes(app)
+    routes, versioned_paths = _iter_openapi_routes(app)
 
-    versioned_paths = {route.path_format for route in routes if isinstance(route, VersionedAPIRoute)}
-    assert versioned_paths == {"/api/test/:1.0", "/api/test/:2.0", "/api/test/:1.1"}
+    expected: typing.Final = {"/api/test/:1.0", "/api/test/:2.0", "/api/test/:1.1"}
+    assert versioned_paths == expected
+    assert {route.path_format for route in routes if isinstance(route, VersionedAPIRoute)} == expected
 
 
 async def test_openapi_schema_with_prefix() -> None:
@@ -206,3 +207,26 @@ async def test_openapi_schema_distinct_models_with_shared_name_across_versions()
     schemas = schema["components"]["schemas"]
     assert set(schemas[v1_ref.rsplit("/", 1)[-1]]["properties"]) == {"name"}
     assert set(schemas[v2_ref.rsplit("/", 1)[-1]]["properties"]) == {"name", "price"}
+
+
+async def test_openapi_schema_preserves_non_versioned_path_with_colon() -> None:
+    # A non-versioned path may legitimately contain a colon (custom-method REST style).
+    # It must not be mistaken for a version suffix and rewritten.
+    plain_router = fastapi.APIRouter()
+
+    class _Payload(pydantic.BaseModel):
+        value: str
+
+    @plain_router.post("/resource:activate")
+    async def _activate(_: _Payload) -> dict[str, typing.Any]:
+        return {}
+
+    app = fastapi.FastAPI()
+    init_fastapi_versioning(app=app, vendor_media_type=VERSION_HEADER)
+    app.include_router(plain_router)
+    client = TestClient(app=app)
+
+    schema = client.get("/openapi.json").json()
+    assert "/resource:activate" in schema["paths"]
+    content = schema["paths"]["/resource:activate"]["post"]["requestBody"]["content"]
+    assert set(content.keys()) == {"application/json"}


### PR DESCRIPTION
## Problem

After a dependency upgrade, `test_openapi_schema` fails: same-path versioned routes collapse to a single entry in the generated OpenAPI schema (e.g. `GET /test/` keeps only `version=2.0`). Runtime request routing is unaffected — only schema generation.

Root cause is a routing/OpenAPI refactor in **FastAPI 0.139 / Starlette 1.3.1**:
- `app.include_router` no longer flattens routes into `app.routes`; it stores an opaque `_IncludedRouter`, so the old `_custom_openapi` (which scanned `app.routes` for `VersionedAPIRoute`) found nothing to disambiguate.
- `get_openapi` now reads `path_format` through an effective-route-context layer, so the previous "copy the route, mutate `path_format`" trick no longer takes effect.

## Fix

Adapt the original single-`get_openapi`-call mechanism to the new route model:

1. Enumerate routes via `fastapi.routing.iter_route_contexts` (sees routes nested in included routers, with effective prefixed paths).
2. Shallow-copy each versioned route with `path_format` suffixed by `:<version>` and pass everything through **one** `get_openapi` call.
3. Post-process: match the exact version-suffixed paths, rewrite request-body media types to `<vendor>; version=X.Y`, and merge per-version operations back onto the real path.

A single call is deliberate and load-bearing: FastAPI disambiguates same-named-but-different Pydantic models only within one call. A per-version-call variant was prototyped and rejected because it silently corrupts the schema when two versions define different models sharing a class name (e.g. an `Item` that gains a field in v2) — guarded now by a regression test.

## Tests

Added under `tests/test_app.py` (existing suite still passes):
- prefixed-router schema (`include_router(prefix=...)`),
- `_iter_openapi_routes` finds versioned routes behind a prefix,
- same-named/different-shape models across versions produce distinct component schemas,
- a non-versioned path containing a literal colon (`/resource:activate`) is not mistaken for a version suffix.

20 passed, `ruff` (ALL) + `mypy --strict` clean, 100% coverage on `app.py` and `router.py`.

## Notes

- Dev dependency `httpx` → `httpx2` (Starlette 1.3's TestClient prefers `httpx2`); unrelated to the fix but rides along.
- Known pre-existing limitations (not introduced here): multiple request content-types on one operation collapse onto the single versioned key; mixing a versioned and non-versioned route at an identical path can overwrite on merge.
- Includes a `CLAUDE.md` and the design spec/plan under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)