### PR TITLE
chore: align package metadata with modern-python convention

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,16 @@
 [project]
 name = "fast-version"
-description = "Fastapi versioning package with accept header"
+description = "Versioning APIs in FastAPI by Accept-header"
 authors = [
     { name = "Artur Shiriev", email = "me@shiriev.ru" },
 ]
 readme = "README.md"
 requires-python = ">=3.10,<4"
 license = "MIT"
-keywords = ["fastapi", "versioning", "accept-header"]
+keywords = ["accept-header", "api-versioning", "fastapi", "openapi", "python", "rest", "versioning"]
 classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -21,12 +23,12 @@ version = "0"
 dependencies = [
     "fastapi>=0.100",
 ]
-packages = [
-    { include = "fast_version" },
-]
 
 [project.urls]
-repository = "https://github.com/community-of-python/fast-version"
+Homepage = "https://github.com/community-of-python/fast-version"
+Repository = "https://github.com/community-of-python/fast-version"
+Issues = "https://github.com/community-of-python/fast-version/issues"
+Changelog = "https://github.com/community-of-python/fast-version/releases"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Aligns package metadata with the `modern-python` convention (the design's deferred follow-up from the ty/CI migration).

- `description` now matches the GitHub repo blurb: "Versioning APIs in FastAPI by Accept-header" (purpose-first, correct FastAPI casing).
- `keywords` mirror the GitHub topics: accept-header, api-versioning, fastapi, openapi, python, rest, versioning.
- Add `Development Status :: 5 - Production/Stable` and `Intended Audience :: Developers` classifiers.
- `[project.urls]` uses PyPI well-known labels: Homepage / Repository / Issues / Changelog (no Documentation — no docs site).
- Remove the dead poetry-style `packages = [...]` key (`uv_build` ignores it).

Verified: `uv build` succeeds and the built wheel METADATA carries the new Summary/Keywords/Classifiers/Project-URLs; `lint-ci` clean; `test-ci` 20 passed at 100%. GitHub repo topics and website field are being set to match (out-of-repo, alongside this PR).