### PR TITLE
refactor: extract Accept-header version parse into a deep accept.py module

### DIFF
--- a/fast_version/accept.py
+++ b/fast_version/accept.py
@@ -1,0 +1,60 @@
+import contextlib
+import dataclasses
+import re
+import typing
+
+from starlette import datastructures, types
+
+
+_VERSION_RE: typing.Final = re.compile(r"^\d\.\d$")
+DEFAULT_VERSION: typing.Final = (1, 0)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Ignore:
+    """Passthrough: the request selects no version; the downstream default applies."""
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ParsedVersion:
+    version: tuple[int, int]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ParseError:
+    detail: str
+
+
+AcceptVersion: typing.TypeAlias = Ignore | ParsedVersion | ParseError
+
+
+def get_accept_header_from_scope(scope: types.Scope) -> str:
+    headers = datastructures.Headers(scope=scope)
+    return headers.get("Accept", "").strip().lower()
+
+
+def parse_accept_version(accept_header: str, vendor_media_type: str) -> AcceptVersion:
+    if not accept_header or accept_header == "*/*":
+        return Ignore()
+
+    try:
+        media_type, version_str = accept_header.split(";")
+    except ValueError:
+        return Ignore()
+
+    if media_type.strip() != vendor_media_type:
+        return Ignore()
+
+    version_key = ""
+    version = ""
+    with contextlib.suppress(ValueError):
+        version_key, version = version_str.strip().split("=")
+
+    if version_key.lower().strip() != "version":
+        return ParseError(detail="No version in Accept header")
+
+    if not _VERSION_RE.match(version):
+        return ParseError(detail="Version should be in <major>.<minor> format")
+
+    major_str, minor_str = version.split(".")
+    return ParsedVersion(version=(int(major_str), int(minor_str)))

--- a/fast_version/app.py
+++ b/fast_version/app.py
@@ -1,6 +1,4 @@
-import contextlib
 import copy
-import re
 import typing
 from types import MethodType
 
@@ -11,11 +9,8 @@ from starlette import types
 from starlette.responses import JSONResponse
 from starlette.routing import BaseRoute
 
-from fast_version import helpers
+from fast_version import accept, helpers
 from fast_version.router import VersionedAPIRoute, VersionedAPIRouter
-
-
-_VERSION_RE: typing.Final = re.compile(r"^\d\.\d$")
 
 
 def _get_vendor_media_type() -> str:
@@ -38,48 +33,17 @@ class FastAPIVersioningMiddleware:
         receive: types.Receive,
         send: types.Send,
     ) -> None:
-        error_response: JSONResponse | None = None
-        while True:
-            if scope["type"] != "http":
-                break
-
-            accept_header_from_request = helpers.get_accept_header_from_scope(scope)
-            if not accept_header_from_request or accept_header_from_request == "*/*":
-                break
-
-            media_type: str
-            version_str: str
-            try:
-                media_type, version_str = accept_header_from_request.split(";")
-            except ValueError:
-                break
-
-            if media_type.strip() != _get_vendor_media_type():
-                break
-
-            version = ""
-            version_key = ""
-            with contextlib.suppress(ValueError):
-                version_key, version = version_str.strip().split("=")
-
-            if version_key.lower().strip() != "version":
-                error_response = JSONResponse(
-                    {"detail": "No version in Accept header"},
-                    status_code=400,
-                )
-                break
-
-            if not _VERSION_RE.match(version):
-                error_response = JSONResponse(
-                    {"detail": "Version should be in <major>.<minor> format"},
-                    status_code=400,
-                )
-                break
-
-            scope["version"] = tuple(int(version_part) for version_part in version.split("."))
-            break
-        if error_response:
-            return await error_response(scope, receive, send)
+        if scope["type"] == "http":
+            header = accept.get_accept_header_from_scope(scope)
+            result = accept.parse_accept_version(header, VersionedAPIRouter.VENDOR_MEDIA_TYPE)
+            match result:
+                case accept.ParsedVersion(version):
+                    scope["version"] = version
+                case accept.ParseError(detail):
+                    response = JSONResponse({"detail": detail}, status_code=400)
+                    return await response(scope, receive, send)
+                case accept.Ignore():
+                    pass
         return await self.app(scope, receive, send)
 
 

--- a/fast_version/helpers.py
+++ b/fast_version/helpers.py
@@ -1,7 +1,5 @@
 import typing
 
-from starlette import datastructures, types
-
 
 def dict_merge(dict1: dict[str, typing.Any], dict2: dict[str, typing.Any]) -> None:
     for key in dict2.keys():
@@ -10,11 +8,6 @@ def dict_merge(dict1: dict[str, typing.Any], dict2: dict[str, typing.Any]) -> No
                 dict_merge(dict1[key], dict2[key])
         else:
             dict1[key] = dict2[key]
-
-
-def get_accept_header_from_scope(scope: types.Scope) -> str:
-    headers = datastructures.Headers(scope=scope)
-    return headers.get("Accept", "").strip().lower()
 
 
 class ClassProperty:

--- a/fast_version/router.py
+++ b/fast_version/router.py
@@ -6,10 +6,8 @@ from starlette import types
 from starlette.responses import JSONResponse
 from starlette.routing import Match
 
+from fast_version import accept
 from fast_version.helpers import ClassProperty
-
-
-DEFAULT_VERSION: typing.Final = (1, 0)
 
 
 # ruff: noqa: B009, B010
@@ -28,7 +26,7 @@ class VersionedAPIRoute(APIRoute):
         if match != Match.FULL:
             return match, child_scope
 
-        request_version: tuple[int, int] = scope.get("version", DEFAULT_VERSION)
+        request_version: tuple[int, int] = scope.get("version", accept.DEFAULT_VERSION)
         if request_version == self.version:
             return Match.FULL, child_scope
         return Match.NONE, {}
@@ -44,7 +42,7 @@ class VersionedAPIRouter(APIRouter):
     ) -> typing.Callable[[DecoratedCallable], DecoratedCallable]:
         def decorator(func: DecoratedCallable) -> DecoratedCallable:
             if not hasattr(func, "version"):
-                setattr(func, "version", DEFAULT_VERSION)
+                setattr(func, "version", accept.DEFAULT_VERSION)
             version_str = ".".join([str(x) for x in getattr(func, "version")])
 
             class VersionedJSONResponse(JSONResponse):

--- a/planning/changes/2026-07-04.01-extract-accept-version-parse/design.md
+++ b/planning/changes/2026-07-04.01-extract-accept-version-parse/design.md
@@ -1,0 +1,188 @@
+---
+summary: Extract Accept-header version parsing out of the middleware into a deep fast_version/accept.py module with a sealed-result interface, testable at its own seam.
+---
+
+# Extract the Accept-header version parse into a deep module
+
+## Summary
+
+The logic that turns a request's `Accept` header into a version tuple lives
+inline in `FastAPIVersioningMiddleware.__call__`, expressed as a
+`while True: ... break` loop that mixes ASGI plumbing with string parsing.
+Today the only way to exercise a parse edge case is a full `TestClient`
+round-trip. This change lifts the parse into a new `fast_version/accept.py`
+module — the sole owner of "what a version is and how the `Accept` header
+selects one" — behind a small pure interface returning a sealed result
+(`Ignore | ParsedVersion | ParseError`). The middleware keeps only the ASGI
+scope-type check and header extraction, then maps the result onto
+`scope["version"]` or a 400. Behavior is preserved exactly.
+
+## Motivation
+
+`fast_version/app.py` — `FastAPIVersioningMiddleware.__call__`:
+
+- The parse is a shallow-interfaced, un-seamed body: media-type matching,
+  `;`/`=` splitting, version-key validation, regex validation, and defaulting
+  all sit inside one ASGI method. The interface (an ASGI `__call__`) is nearly
+  as wide as the implementation.
+- Every parse edge case is tested through the ASGI layer:
+  `test_no_version`, the 8-case parametrized `test_invalid_version`,
+  `test_bad_accept_header_default_response`,
+  `test_auto_version_when_no_version_provided` all spin up a full app to
+  exercise a string split.
+- Version knowledge is smeared across files: `_VERSION_RE` in `app.py`,
+  `get_accept_header_from_scope` in the generic `helpers.py`, `DEFAULT_VERSION`
+  in `router.py`. No single module answers "what is a version, what's valid,
+  what's the default."
+
+Deletion test on the inlined parse: extracting it concentrates the parsing
+complexity behind one interface rather than moving it — the signal to deepen.
+
+## Non-goals
+
+- No behavior change. Multi-semicolon → `Ignore` and the lowercased-header
+  comparison are preserved as-is.
+- No fix to the vendor case-sensitivity quirk (see Risk / `deferred.md`) — it
+  gets its own TDD change once the seam exists.
+- No change to `VersionedAPIRoute.matches`. Matching a request's version
+  against a route's version is routing's job and stays in `router.py`.
+- No change to the public API (`VersionedAPIRouter`, `init_fastapi_versioning`).
+  `parse_accept_version` is internal.
+
+## Design
+
+### 1. New module `fast_version/accept.py`
+
+Sole owner of Accept-header version negotiation. Absorbs `_VERSION_RE` (from
+`app.py`), `get_accept_header_from_scope` (from `helpers.py`), and
+`DEFAULT_VERSION` (from `router.py`).
+
+```python
+import dataclasses
+import re
+import typing
+
+from starlette import datastructures, types
+
+
+_VERSION_RE: typing.Final = re.compile(r"^\d\.\d$")
+DEFAULT_VERSION: typing.Final = (1, 0)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Ignore:
+    """Passthrough: the request selects no version; the downstream default applies."""
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ParsedVersion:
+    version: tuple[int, int]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ParseError:
+    detail: str
+
+
+AcceptVersion: typing.TypeAlias = Ignore | ParsedVersion | ParseError
+
+
+def get_accept_header_from_scope(scope: types.Scope) -> str:
+    headers = datastructures.Headers(scope=scope)
+    return headers.get("Accept", "").strip().lower()
+
+
+def parse_accept_version(accept_header: str, vendor_media_type: str) -> AcceptVersion:
+    ...
+```
+
+`parse_accept_version` owns steps 3-7 of today's middleware, in order,
+preserving each outcome exactly:
+
+1. Empty header or `*/*` → `Ignore`.
+2. `accept_header.split(";")` does not yield exactly two parts (0 or 2+
+   semicolons) → `Ignore`.
+3. `media_type.strip() != vendor_media_type` → `Ignore`.
+4. The value part does not split into exactly `key=value`, or
+   `key.lower().strip() != "version"` → `ParseError("No version in Accept header")`.
+5. `_VERSION_RE` does not match the value → `ParseError("Version should be in
+   <major>.<minor> format")`.
+6. Otherwise → `ParsedVersion((major, minor))`.
+
+The function is pure: no `scope`, no Starlette response types, no class-level
+global. `vendor_media_type` is a plain argument.
+
+### 2. Middleware becomes thin ASGI glue
+
+`FastAPIVersioningMiddleware.__call__` keeps only the ASGI scope-type check and
+header extraction, then `match`es the parse result:
+
+```python
+async def __call__(self, scope, receive, send) -> None:
+    if scope["type"] == "http":
+        header = accept.get_accept_header_from_scope(scope)
+        result = accept.parse_accept_version(header, VersionedAPIRouter.VENDOR_MEDIA_TYPE)
+        match result:
+            case accept.ParsedVersion(version):
+                scope["version"] = version
+            case accept.ParseError(detail):
+                response = JSONResponse({"detail": detail}, status_code=400)
+                return await response(scope, receive, send)
+            case accept.Ignore():
+                pass
+    return await self.app(scope, receive, send)
+```
+
+The `while True: ... break` loop, `contextlib.suppress`, and `_get_vendor_media_type`
+usage in the middleware are gone. (`_get_vendor_media_type` remains only if
+still used by `_custom_openapi`; it is — leave it.)
+
+### 3. Downstream owners updated
+
+- `router.py`: delete the local `DEFAULT_VERSION` and import it from
+  `fast_version.accept`. `VersionedAPIRoute.matches` keeps
+  `scope.get("version", accept.DEFAULT_VERSION)`.
+- `helpers.py`: delete `get_accept_header_from_scope` (moved to `accept.py`).
+  `dict_merge` and `ClassProperty` stay.
+- `app.py`: delete `_VERSION_RE`, import `accept`, drop the inlined parse.
+
+No import cycle: `accept.py` depends only on `starlette`/stdlib; `app.py` and
+`router.py` import `accept`.
+
+## Testing
+
+- **New `tests/test_accept.py`** — exhaustive, pure unit tests on
+  `parse_accept_version`, no `TestClient`:
+  - `Ignore`: `""`, `"*/*"`, no-semicolon (`vendor` alone),
+    multi-semicolon (`vendor; version=1.0; charset=utf-8`), wrong vendor.
+  - `ParsedVersion`: `1.0`, `2.0` → `(1, 0)`, `(2, 0)`.
+  - `ParseError("No version in Accept header")`: `vendor; vers1.1`,
+    `vendor; vers=1.1`.
+  - `ParseError("Version should be in <major>.<minor> format")`: the 8-case
+    parametrized list from today's `test_invalid_version`
+    (`"", "test", "0,.1", "0,1", "0,1,1", "0-1", "0/1", "1-1"`).
+  - Assertions compare whole result values (frozen dataclass `__eq__`), e.g.
+    `assert parse_accept_version("*/*", VENDOR) == Ignore()`.
+- **`tests/test_app.py`** — thinned to one round-trip per outcome, proving the
+  middleware wires parse → `scope`/`JSONResponse`: keep a 200-with-version,
+  a 400-no-version, a 400-bad-format, and a passthrough-default assertion.
+  Remove the exhaustive enumeration now covered at the parse seam.
+- `just test-ci` — coverage stays at `--cov-fail-under=100`. Parse branch
+  lines are covered by `test_accept.py`; the four middleware-mapping branches
+  by the retained round-trips.
+- `just lint-ci` — ruff `select = ["ALL"]` and `ty` clean; `just check-planning`.
+
+## Risk
+
+- **Coverage regression (medium likelihood, low impact).** Thinning
+  `test_app.py` while adding `test_accept.py` could drop a covered middleware
+  branch. Mitigation: the four retained round-trips map 1:1 to the four
+  `match` arms; run `just test-ci` before pushing.
+- **Behavior drift in the split logic (low likelihood, high impact).** The
+  multi-semicolon and lowercase-comparison quirks are easy to "tidy" away.
+  Mitigation: `test_accept.py` pins them explicitly as `Ignore`/comparison
+  cases; the change is behavior-preserving by contract.
+- **Deferred: vendor case-sensitivity.** The comparison runs a lowercased
+  header media-type against a non-lowercased `vendor_media_type`; a mixed-case
+  vendor silently never matches. Recorded in `deferred.md` as a follow-up TDD
+  fix, cheap to write once the seam exists.

--- a/planning/changes/2026-07-04.01-extract-accept-version-parse/design.md
+++ b/planning/changes/2026-07-04.01-extract-accept-version-parse/design.md
@@ -1,5 +1,5 @@
 ---
-summary: Extract Accept-header version parsing out of the middleware into a deep fast_version/accept.py module with a sealed-result interface, testable at its own seam.
+summary: Extracted Accept-header version parsing into fast_version/accept.py behind a sealed-result interface (Ignore | ParsedVersion | ParseError); exhaustive cases moved to the parse seam and DEFAULT_VERSION relocated to accept.py.
 ---
 
 # Extract the Accept-header version parse into a deep module

--- a/planning/changes/2026-07-04.01-extract-accept-version-parse/plan.md
+++ b/planning/changes/2026-07-04.01-extract-accept-version-parse/plan.md
@@ -1,0 +1,450 @@
+# extract-accept-version-parse — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move Accept-header version parsing into a pure `fast_version/accept.py`
+module with a sealed-result interface, testable at its own seam, preserving
+behavior.
+
+**Spec:** [`design.md`](./design.md)
+
+**Branch:** `refactor/extract-accept-version-parse`
+
+**Commit strategy:** Per-task commits.
+
+## Global constraints
+
+- Python 3.10-3.14; `match`/`|` unions available.
+- Ruff `select = ["ALL"]`, line length 120, and `ty` must pass (`just lint-ci`).
+- Use `ty: ignore`, never `type: ignore`.
+- All imports at module level; annotate all function arguments.
+- Coverage gate: `just test-ci` runs `--cov-fail-under=100`. Every task's
+  commit must leave the suite green at 100%.
+- Behavior-preserving: no route, response, or error-message change.
+
+---
+
+### Task 1: Create the `accept.py` parse module (TDD)
+
+**Files:**
+- Create: `fast_version/accept.py`
+- Create: `tests/test_accept.py`
+
+**Interfaces produced (later tasks rely on these exact names/types):**
+- `fast_version.accept.Ignore` — frozen dataclass, no fields.
+- `fast_version.accept.ParsedVersion(version: tuple[int, int])` — frozen dataclass.
+- `fast_version.accept.ParseError(detail: str)` — frozen dataclass.
+- `fast_version.accept.AcceptVersion` — `Ignore | ParsedVersion | ParseError`.
+- `fast_version.accept.DEFAULT_VERSION: tuple[int, int] = (1, 0)`.
+- `fast_version.accept.get_accept_header_from_scope(scope) -> str`.
+- `fast_version.accept.parse_accept_version(accept_header: str, vendor_media_type: str) -> AcceptVersion`.
+
+This task adds the new module and its unit tests. Old copies of
+`get_accept_header_from_scope` (helpers), `_VERSION_RE` (app), and
+`DEFAULT_VERSION` (router) remain in place until later tasks — temporary
+duplication, suite stays green.
+
+- [ ] **Step 1: Write the failing tests**
+
+  Create `tests/test_accept.py`:
+
+  ```python
+  import typing
+
+  import pytest
+
+  from fast_version.accept import (
+      Ignore,
+      ParsedVersion,
+      ParseError,
+      get_accept_header_from_scope,
+      parse_accept_version,
+  )
+
+
+  VENDOR: typing.Final = "application/vnd.some.name+json"
+
+
+  @pytest.mark.parametrize(
+      "header",
+      [
+          "",
+          "*/*",
+          VENDOR,  # no semicolon -> split yields one part
+          f"{VENDOR}; version=1.0; charset=utf-8",  # two semicolons
+          "application/vnd.wrong+json; version=1.0",  # wrong vendor
+      ],
+  )
+  def test_parse_ignore(header: str) -> None:
+      assert parse_accept_version(header, VENDOR) == Ignore()
+
+
+  @pytest.mark.parametrize(
+      ("header", "expected"),
+      [
+          (f"{VENDOR}; version=1.0", (1, 0)),
+          (f"{VENDOR}; version=2.0", (2, 0)),
+      ],
+  )
+  def test_parse_version(header: str, expected: tuple[int, int]) -> None:
+      assert parse_accept_version(header, VENDOR) == ParsedVersion(version=expected)
+
+
+  @pytest.mark.parametrize(
+      "header",
+      [f"{VENDOR}; vers1.1", f"{VENDOR}; vers=1.1"],
+  )
+  def test_parse_missing_version_key(header: str) -> None:
+      assert parse_accept_version(header, VENDOR) == ParseError(detail="No version in Accept header")
+
+
+  @pytest.mark.parametrize(
+      "version",
+      ["", "test", "0,.1", "0,1", "0,1,1", "0-1", "0/1", "1-1"],
+  )
+  def test_parse_bad_version_format(version: str) -> None:
+      result = parse_accept_version(f"{VENDOR}; version={version}", VENDOR)
+      assert result == ParseError(detail="Version should be in <major>.<minor> format")
+
+
+  def test_get_accept_header_from_scope_normalizes() -> None:
+      scope: typing.Final = {"type": "http", "headers": [(b"accept", b"  Foo/Bar  ")]}
+      assert get_accept_header_from_scope(scope) == "foo/bar"
+
+
+  def test_get_accept_header_from_scope_missing() -> None:
+      assert get_accept_header_from_scope({"type": "http", "headers": []}) == ""
+  ```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+  Run: `uv run pytest tests/test_accept.py -q`
+  Expected: FAIL — `ModuleNotFoundError: No module named 'fast_version.accept'`.
+
+- [ ] **Step 3: Create the module**
+
+  Create `fast_version/accept.py`:
+
+  ```python
+  import contextlib
+  import dataclasses
+  import re
+  import typing
+
+  from starlette import datastructures, types
+
+
+  _VERSION_RE: typing.Final = re.compile(r"^\d\.\d$")
+  DEFAULT_VERSION: typing.Final = (1, 0)
+
+
+  @dataclasses.dataclass(frozen=True, slots=True)
+  class Ignore:
+      """Passthrough: the request selects no version; the downstream default applies."""
+
+
+  @dataclasses.dataclass(frozen=True, slots=True)
+  class ParsedVersion:
+      version: tuple[int, int]
+
+
+  @dataclasses.dataclass(frozen=True, slots=True)
+  class ParseError:
+      detail: str
+
+
+  AcceptVersion: typing.TypeAlias = Ignore | ParsedVersion | ParseError
+
+
+  def get_accept_header_from_scope(scope: types.Scope) -> str:
+      headers = datastructures.Headers(scope=scope)
+      return headers.get("Accept", "").strip().lower()
+
+
+  def parse_accept_version(accept_header: str, vendor_media_type: str) -> AcceptVersion:
+      if not accept_header or accept_header == "*/*":
+          return Ignore()
+
+      try:
+          media_type, version_str = accept_header.split(";")
+      except ValueError:
+          return Ignore()
+
+      if media_type.strip() != vendor_media_type:
+          return Ignore()
+
+      version_key = ""
+      version = ""
+      with contextlib.suppress(ValueError):
+          version_key, version = version_str.strip().split("=")
+
+      if version_key.lower().strip() != "version":
+          return ParseError(detail="No version in Accept header")
+
+      if not _VERSION_RE.match(version):
+          return ParseError(detail="Version should be in <major>.<minor> format")
+
+      major_str, minor_str = version.split(".")
+      return ParsedVersion(version=(int(major_str), int(minor_str)))
+  ```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+  Run: `uv run pytest tests/test_accept.py -q`
+  Expected: PASS (all cases).
+
+- [ ] **Step 5: Lint**
+
+  Run: `just lint` then `just lint-ci`
+  Expected: clean (ruff + ty).
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add fast_version/accept.py tests/test_accept.py
+  git commit -m "refactor: add accept.py version-parse module with unit tests"
+  ```
+
+---
+
+### Task 2: Rewire the middleware; drop the inline parse
+
+**Files:**
+- Modify: `fast_version/app.py` (imports; `FastAPIVersioningMiddleware.__call__`)
+- Modify: `fast_version/helpers.py` (remove `get_accept_header_from_scope`)
+
+**Interfaces consumed:** `accept.parse_accept_version`,
+`accept.get_accept_header_from_scope`, `accept.Ignore/ParsedVersion/ParseError`.
+
+Middleware now delegates to the parse module. `helpers.get_accept_header_from_scope`
+is removed in the same task so it does not become uncovered dead code.
+
+- [ ] **Step 1: Rewrite `FastAPIVersioningMiddleware.__call__`**
+
+  In `fast_version/app.py`, replace the entire `while True: ... break` body of
+  `__call__` (currently lines ~35-83) with:
+
+  ```python
+      async def __call__(
+          self,
+          scope: types.Scope,
+          receive: types.Receive,
+          send: types.Send,
+      ) -> None:
+          if scope["type"] == "http":
+              header = accept.get_accept_header_from_scope(scope)
+              result = accept.parse_accept_version(header, VersionedAPIRouter.VENDOR_MEDIA_TYPE)
+              match result:
+                  case accept.ParsedVersion(version):
+                      scope["version"] = version
+                  case accept.ParseError(detail):
+                      response = JSONResponse({"detail": detail}, status_code=400)
+                      return await response(scope, receive, send)
+                  case accept.Ignore():
+                      pass
+          return await self.app(scope, receive, send)
+  ```
+
+- [ ] **Step 2: Fix `app.py` imports**
+
+  In `fast_version/app.py`:
+  - Delete `import contextlib` and `import re` (no longer used).
+  - Delete the module-level `_VERSION_RE = re.compile(...)` line and the
+    `_get_vendor_media_type` call inside the old middleware (removed with the body).
+  - Add `from fast_version import accept` to the `fast_version` imports.
+  - Keep `from fast_version import helpers` (still used by `_custom_openapi`)
+    and `_get_vendor_media_type` (still used by `_custom_openapi`).
+
+- [ ] **Step 3: Remove the moved helper**
+
+  In `fast_version/helpers.py`, delete `get_accept_header_from_scope`. Then
+  remove the now-unused import: change `from starlette import datastructures, types`
+  to delete the line entirely (neither is used by `dict_merge`/`ClassProperty`).
+  The file keeps only `import typing`, `dict_merge`, and `ClassProperty`.
+
+- [ ] **Step 4: Run the full suite**
+
+  Run: `just test`
+  Expected: PASS — existing `test_app.py` round-trips (get/post/no-version/
+  invalid/bad-vendor/auto) still pass unchanged.
+
+- [ ] **Step 5: Coverage + lint**
+
+  Run: `just test-ci` then `just lint-ci`
+  Expected: coverage 100%, ruff + ty clean.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add fast_version/app.py fast_version/helpers.py
+  git commit -m "refactor: delegate Accept-header parsing to accept.py"
+  ```
+
+---
+
+### Task 3: Relocate `DEFAULT_VERSION` to `accept.py`
+
+**Files:**
+- Modify: `fast_version/router.py`
+
+Completes the single-owner: the version default now lives beside the version
+regex and result types. `VersionedAPIRoute.matches` keeps its behavior.
+
+- [ ] **Step 1: Point router at `accept.DEFAULT_VERSION`**
+
+  In `fast_version/router.py`:
+  - Delete `DEFAULT_VERSION: typing.Final = (1, 0)`.
+  - Add `from fast_version import accept` to the imports.
+  - In `VersionedAPIRoute.matches`, change
+    `scope.get("version", DEFAULT_VERSION)` to
+    `scope.get("version", accept.DEFAULT_VERSION)`.
+  - In `VersionedAPIRouter.api_route`'s decorator, the default assignment
+    `setattr(func, "version", DEFAULT_VERSION)` becomes
+    `setattr(func, "version", accept.DEFAULT_VERSION)`.
+
+- [ ] **Step 2: Run the full suite**
+
+  Run: `just test`
+  Expected: PASS (matching + defaulting unchanged).
+
+- [ ] **Step 3: Coverage + lint**
+
+  Run: `just test-ci` then `just lint-ci`
+  Expected: coverage 100%, ruff + ty clean. No import cycle
+  (`accept` depends only on starlette/stdlib).
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add fast_version/router.py
+  git commit -m "refactor: move DEFAULT_VERSION into accept.py"
+  ```
+
+---
+
+### Task 4: Thin `test_app.py` to one round-trip per outcome
+
+**Files:**
+- Modify: `tests/test_app.py`
+
+Exhaustive parse enumeration now lives in `test_accept.py`. `test_app.py`
+retains one round-trip per middleware `match` arm, proving the wiring. OpenAPI
+tests (`test_openapi_*`, `test_iter_openapi_routes_*`) are unrelated — leave
+them untouched.
+
+- [ ] **Step 1: Reduce the parse round-trips**
+
+  In `tests/test_app.py`:
+  - Keep `test_get`, `test_post`, `test_simple_router` unchanged (they cover
+    the `ParsedVersion` arm and non-versioned routing).
+  - Keep `test_auto_version_when_no_version_provided` unchanged (the `Ignore`
+    arm — passthrough default content-type).
+  - Delete `test_bad_accept_header_default_response` (a second `Ignore` case,
+    now covered exhaustively in `test_accept.py`).
+  - Replace `test_no_version` (two requests) with a single-request version:
+
+    ```python
+    async def test_no_version(test_client: TestClient) -> None:
+        response = test_client.get(
+            "/test/",
+            headers={"Accept": f"{VERSION_HEADER}; vers=1.1"},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {"detail": "No version in Accept header"}
+    ```
+
+  - Replace the parametrized `test_invalid_version` (8 cases) with a single
+    bad-format round-trip:
+
+    ```python
+    async def test_invalid_version_format(test_client: TestClient) -> None:
+        response = test_client.get(
+            "/test/",
+            headers={"Accept": f"{VERSION_HEADER}; version=1-1"},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {"detail": "Version should be in <major>.<minor> format"}
+    ```
+
+  - Remove the now-unused `@pytest.mark.parametrize` import usage if it leaves
+    `pytest` unused (it does not — `pytestmark`/fixtures still use it).
+
+- [ ] **Step 2: Run the full suite**
+
+  Run: `just test`
+  Expected: PASS.
+
+- [ ] **Step 3: Coverage must stay at 100%**
+
+  Run: `just test-ci`
+  Expected: coverage 100% — the four retained round-trips map 1:1 to the
+  `ParsedVersion` / `ParseError(no version)` / `ParseError(bad format)` /
+  `Ignore` arms; parse branches are covered by `test_accept.py`.
+  If any middleware line is uncovered, restore the matching round-trip.
+
+- [ ] **Step 4: Lint**
+
+  Run: `just lint-ci`
+  Expected: ruff + ty clean.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add tests/test_app.py
+  git commit -m "test: move exhaustive parse cases to the accept seam"
+  ```
+
+---
+
+### Task 5: Record the deferred fix and finalize the bundle
+
+**Files:**
+- Modify: `planning/deferred.md`
+- Modify: `planning/changes/2026-07-04.01-extract-accept-version-parse/design.md` (finalize `summary`)
+
+Behavior is unchanged, so no `architecture/<capability>.md` promotion is
+required by the rule. Record the case-sensitivity follow-up and finalize the
+bundle summary.
+
+- [ ] **Step 1: Append the deferred item**
+
+  Add to `planning/deferred.md`:
+
+  ```markdown
+  - **Vendor media-type case-sensitivity** — `parse_accept_version` compares a
+    lowercased header media-type against a non-lowercased `vendor_media_type`,
+    so a mixed-case vendor never matches (silently falls through to `Ignore`).
+    Revisit trigger: a user configures a vendor type with uppercase letters, or
+    we decide to guarantee case-insensitive media-type matching. Fix is a
+    failing `tests/test_accept.py` case plus a `.lower()` on the vendor.
+  ```
+
+- [ ] **Step 2: Finalize the design summary**
+
+  In the bundle's `design.md`, update the `summary:` frontmatter to state the
+  realized result once the PR number is known, e.g.:
+  `Extracted Accept-header version parsing into fast_version/accept.py behind a
+  sealed-result interface; exhaustive cases moved to the parse seam (shipped in #NN).`
+
+- [ ] **Step 3: Validate planning + full CI checks**
+
+  Run: `just check-planning` then `just lint-ci` then `just test-ci`
+  Expected: all pass; coverage 100%.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add planning/deferred.md planning/changes/2026-07-04.01-extract-accept-version-parse/design.md
+  git commit -m "docs(planning): record deferred vendor case-sensitivity fix"
+  ```
+
+---
+
+## Finish
+
+Push the branch and open a PR (never local-merge). Watch PR CI across Python
+3.10-3.14. After merge: `git pull --ff-only` on `main`, delete the local
+branch, `git remote prune origin`.

--- a/planning/deferred.md
+++ b/planning/deferred.md
@@ -1,3 +1,10 @@
 # Deferred
 
-Real-but-unscheduled items, each with a revisit trigger. Empty for now.
+Real-but-unscheduled items, each with a revisit trigger.
+
+- **Vendor media-type case-sensitivity** — `parse_accept_version` compares a
+  lowercased header media-type against a non-lowercased `vendor_media_type`,
+  so a mixed-case vendor never matches (silently falls through to `Ignore`).
+  Revisit trigger: a user configures a vendor type with uppercase letters, or
+  we decide to guarantee case-insensitive media-type matching. Fix is a
+  failing `tests/test_accept.py` case plus a `.lower()` on the vendor.

--- a/tests/test_accept.py
+++ b/tests/test_accept.py
@@ -1,0 +1,65 @@
+import typing
+
+import pytest
+
+from fast_version.accept import (
+    Ignore,
+    ParsedVersion,
+    ParseError,
+    get_accept_header_from_scope,
+    parse_accept_version,
+)
+
+
+VENDOR: typing.Final = "application/vnd.some.name+json"
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "",
+        "*/*",
+        VENDOR,  # no semicolon -> split yields one part
+        f"{VENDOR}; version=1.0; charset=utf-8",  # two semicolons
+        "application/vnd.wrong+json; version=1.0",  # wrong vendor
+    ],
+)
+def test_parse_ignore(header: str) -> None:
+    assert parse_accept_version(header, VENDOR) == Ignore()
+
+
+@pytest.mark.parametrize(
+    ("header", "expected"),
+    [
+        (f"{VENDOR}; version=1.0", (1, 0)),
+        (f"{VENDOR}; version=2.0", (2, 0)),
+    ],
+)
+def test_parse_version(header: str, expected: tuple[int, int]) -> None:
+    assert parse_accept_version(header, VENDOR) == ParsedVersion(version=expected)
+
+
+@pytest.mark.parametrize(
+    "header",
+    [f"{VENDOR}; vers1.1", f"{VENDOR}; vers=1.1"],
+)
+def test_parse_missing_version_key(header: str) -> None:
+    assert parse_accept_version(header, VENDOR) == ParseError(detail="No version in Accept header")
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["", "test", "0,.1", "0,1", "0,1,1", "0-1", "0/1", "1-1"],
+)
+def test_parse_bad_version_format(version: str) -> None:
+    result = parse_accept_version(f"{VENDOR}; version={version}", VENDOR)
+    assert result == ParseError(detail="Version should be in <major>.<minor> format")
+
+
+def test_get_accept_header_from_scope_normalizes() -> None:
+    scope: typing.Final = {"type": "http", "headers": [(b"accept", b"  Foo/Bar  ")]}
+    assert get_accept_header_from_scope(scope) == "foo/bar"
+
+
+def test_get_accept_header_from_scope_missing() -> None:
+    assert get_accept_header_from_scope({"type": "http", "headers": []}) == ""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -78,23 +78,7 @@ async def test_simple_router(test_client: TestClient) -> None:
         assert text == "Hello, world!"
 
 
-async def test_bad_accept_header_default_response(test_client: TestClient) -> None:
-    response = test_client.get(
-        "/test/",
-        headers={"Accept": "application/vnd.wrong+json; version=1.0"},
-    )
-    assert response.status_code == status.HTTP_200_OK
-    assert response.headers["content-type"] == f"{VERSION_HEADER}; version=1.0"
-
-
 async def test_no_version(test_client: TestClient) -> None:
-    response = test_client.get(
-        "/test/",
-        headers={"Accept": f"{VERSION_HEADER}; vers1.1"},
-    )
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json() == {"detail": "No version in Accept header"}
-
     response = test_client.get(
         "/test/",
         headers={"Accept": f"{VERSION_HEADER}; vers=1.1"},
@@ -103,14 +87,10 @@ async def test_no_version(test_client: TestClient) -> None:
     assert response.json() == {"detail": "No version in Accept header"}
 
 
-@pytest.mark.parametrize(
-    "version",
-    ["", "test", "0,.1", "0,1", "0,1,1", "0-1", "0/1", "1-1"],
-)
-async def test_invalid_version(test_client: TestClient, version: str) -> None:
+async def test_invalid_version_format(test_client: TestClient) -> None:
     response = test_client.get(
         "/test/",
-        headers={"Accept": f"{VERSION_HEADER}; version={version}"},
+        headers={"Accept": f"{VERSION_HEADER}; version=1-1"},
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json() == {"detail": "Version should be in <major>.<minor> format"}


### PR DESCRIPTION
## What

Behavior-preserving refactor. Lifts the Accept-header version parsing out of `FastAPIVersioningMiddleware.__call__` (an inline `while True/break` loop that mixed ASGI plumbing with string parsing) into a new pure module `fast_version/accept.py` with a sealed-result interface:

```python
parse_accept_version(accept_header: str, vendor_media_type: str) -> Ignore | ParsedVersion | ParseError
```

The middleware now `match`es on the result. `accept.py` becomes the single owner of the version concept: it absorbs `_VERSION_RE` (from `app.py`), `get_accept_header_from_scope` (from `helpers.py`), and `DEFAULT_VERSION` (from `router.py`).

## Why

The parse had no seam of its own — every edge case was tested through a full `TestClient` round-trip. Now the branching lives behind a small pure interface (the deletion test concentrates the complexity rather than moving it), directly unit-testable without an ASGI app. `VersionedAPIRoute.matches` is unchanged: `accept.py` owns *what a version is*; `router.py` owns *matching on it*.

## Changes

- **New `fast_version/accept.py`** — three frozen dataclasses (`Ignore` / `ParsedVersion(version)` / `ParseError(detail)`), the `AcceptVersion` union, `parse_accept_version`, `get_accept_header_from_scope`, `DEFAULT_VERSION`, `_VERSION_RE`.
- **`app.py`** — middleware reduced to ASGI scope-type check + header extraction + `match`; inline parse, `_VERSION_RE`, `import contextlib`/`import re` removed.
- **`helpers.py`** — `get_accept_header_from_scope` moved out; keeps `dict_merge` + `ClassProperty`.
- **`router.py`** — `DEFAULT_VERSION` now imported from `accept`.
- **Tests** — exhaustive parse cases moved to new `tests/test_accept.py` (pure, no `TestClient`); `tests/test_app.py` thinned to one round-trip per middleware `match` arm.

## Behavior

Preserved exactly — same routes, same two 400 detail strings, same content-type, same `(1, 0)` default, including the multi-semicolon -> Ignore and lowercased-header quirks. Vendor media-type case-sensitivity is a pre-existing quirk recorded in `planning/deferred.md` as a separate follow-up (not touched here).

## Verification

- `just test-ci` — 31 passed, coverage 100%.
- `just lint-ci` — ruff (`select = ["ALL"]`) + ty clean; `planning: OK`.

Planning bundle: `planning/changes/2026-07-04.01-extract-accept-version-parse/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)