### PR TITLE
refactor: extract _collapse_versioned_paths from _custom_openapi

### DIFF
--- a/fast_version/app.py
+++ b/fast_version/app.py
@@ -78,6 +78,37 @@ def _iter_openapi_routes(
     return routes, versioned_paths
 
 
+def _collapse_versioned_paths(
+    raw_paths: dict[str, typing.Any],
+    versioned_paths: set[str],
+    vendor_media_type: str,
+) -> dict[str, typing.Any]:
+    """Collapse the per-version ``:<version>`` suffixed paths back onto their real path.
+
+    Only request bodies are versioned (keyed by media type); operation-level fields
+    (parameters, summary, tags, ...) come from the first-merged version, so versions
+    of the same path+method should differ only in body schema.
+    """
+    paths_dict: dict[str, typing.Any] = {}
+    for raw_path, methods in raw_paths.items():
+        if raw_path not in versioned_paths:
+            paths_dict[raw_path] = methods
+            continue
+        clean_path, version_str = raw_path.rsplit(":", 1)
+        for payload in methods.values():
+            if "requestBody" not in payload:
+                continue
+            payload["requestBody"]["content"] = {
+                f"{vendor_media_type}; version={version_str}": content
+                for content in payload["requestBody"]["content"].values()
+            }
+        if clean_path not in paths_dict:
+            paths_dict[clean_path] = methods
+            continue
+        helpers.dict_merge(paths_dict[clean_path], methods)
+    return paths_dict
+
+
 def _custom_openapi(self: fastapi.FastAPI) -> dict[str, typing.Any]:
     if self.openapi_schema:
         return self.openapi_schema
@@ -98,29 +129,9 @@ def _custom_openapi(self: fastapi.FastAPI) -> dict[str, typing.Any]:
         servers=self.servers,
     )
 
-    # Collapse the per-version paths back onto their real path. Only the request/response
-    # bodies are versioned (keyed by media type); operation-level fields (parameters,
-    # summary, tags, ...) are taken from the first-merged version, so versions of the same
-    # path+method should differ only in body schema.
-    vendor_media_type = _get_vendor_media_type()
-    paths_dict: dict[str, typing.Any] = {}
-    raw_path: str
-    methods: dict[str, typing.Any]
-    for raw_path, methods in self.openapi_schema["paths"].items():
-        if raw_path not in versioned_paths:
-            paths_dict[raw_path] = methods
-            continue
-        clean_path, version_str = raw_path.rsplit(":", 1)
-        for payload in methods.values():
-            if "requestBody" not in payload:
-                continue
-            payload["requestBody"]["content"] = {
-                f"{vendor_media_type}; version={version_str}": content
-                for content in payload["requestBody"]["content"].values()
-            }
-        if clean_path not in paths_dict:
-            paths_dict[clean_path] = methods
-            continue
-        helpers.dict_merge(paths_dict[clean_path], methods)
-    self.openapi_schema["paths"] = paths_dict
+    self.openapi_schema["paths"] = _collapse_versioned_paths(
+        self.openapi_schema["paths"],
+        versioned_paths,
+        _get_vendor_media_type(),
+    )
     return self.openapi_schema

--- a/planning/changes/2026-07-04.03-collapse-versioned-paths-seam/design.md
+++ b/planning/changes/2026-07-04.03-collapse-versioned-paths-seam/design.md
@@ -1,5 +1,5 @@
 ---
-summary: Extract the OpenAPI path-collapse/content-rewrite loop out of _custom_openapi into a pure _collapse_versioned_paths function, unit-testable at its own seam, mirroring the already-extracted _iter_openapi_routes.
+summary: Extracted the OpenAPI path-collapse loop into pure _collapse_versioned_paths, unit-tested at its own seam beside _iter_openapi_routes; behavior unchanged.
 ---
 
 # Give the OpenAPI path-collapse its own seam

--- a/planning/changes/2026-07-04.03-collapse-versioned-paths-seam/design.md
+++ b/planning/changes/2026-07-04.03-collapse-versioned-paths-seam/design.md
@@ -1,0 +1,130 @@
+---
+summary: Extract the OpenAPI path-collapse/content-rewrite loop out of _custom_openapi into a pure _collapse_versioned_paths function, unit-testable at its own seam, mirroring the already-extracted _iter_openapi_routes.
+---
+
+# Give the OpenAPI path-collapse its own seam
+
+## Summary
+
+`_custom_openapi` (`fast_version/app.py`) ends with a ~25-line loop that collapses
+the per-version `:<version>`-suffixed paths back onto their real path: it splits
+the suffix, rewrites each `requestBody` content key to `{vendor}; version=X.Y`,
+and merges same-path versions via `helpers.dict_merge`. That loop is a pure
+`dict -> dict` transform, but it lives inside the monkey-patched `app.openapi`, so
+the only way to exercise it is to build an app and fetch `/openapi.json`. This
+change lifts it into `_collapse_versioned_paths(raw_paths, versioned_paths,
+vendor_media_type) -> dict`, testable directly with fixture dicts. Behavior is
+preserved exactly.
+
+## Motivation
+
+`_iter_openapi_routes` — the *first* half of the OpenAPI-versioning transform (build
+the suffixed route list) — is already a module-level function with a direct unit
+test (`test_iter_openapi_routes_finds_prefixed_versioned_paths`). Its second half,
+the schema-collapse loop, was left inline. The asymmetry is the friction: one half
+is testable at a seam, the other only through the full pipeline. Extracting the
+loop completes the pattern and makes the collapse rules (colon split, content-key
+rewrite, per-version merge) verifiable without an ASGI round-trip.
+
+This is a modest tidy-up, not a hot spot — the integration tests already cover the
+happy paths. The win is locality and a unit seam, not a bug surface.
+
+## Non-goals
+
+- No behavior change. The in-place `requestBody` content rewrite and the
+  `dict_merge` semantics are preserved exactly.
+- No new module. The function sits next to `_iter_openapi_routes` in `app.py`
+  (see the rejected alternative below).
+- No change to `_iter_openapi_routes`, the middleware, or the response-class
+  mechanism.
+
+## Design
+
+### 1. New module-level function in `app.py`
+
+```python
+def _collapse_versioned_paths(
+    raw_paths: dict[str, typing.Any],
+    versioned_paths: set[str],
+    vendor_media_type: str,
+) -> dict[str, typing.Any]:
+    """Collapse the per-version ``:<version>`` suffixed paths back onto their real path.
+
+    Only request bodies are versioned (keyed by media type); operation-level fields
+    (parameters, summary, tags, ...) come from the first-merged version, so versions
+    of the same path+method should differ only in body schema.
+    """
+    paths_dict: dict[str, typing.Any] = {}
+    for raw_path, methods in raw_paths.items():
+        if raw_path not in versioned_paths:
+            paths_dict[raw_path] = methods
+            continue
+        clean_path, version_str = raw_path.rsplit(":", 1)
+        for payload in methods.values():
+            if "requestBody" not in payload:
+                continue
+            payload["requestBody"]["content"] = {
+                f"{vendor_media_type}; version={version_str}": content
+                for content in payload["requestBody"]["content"].values()
+            }
+        if clean_path not in paths_dict:
+            paths_dict[clean_path] = methods
+            continue
+        helpers.dict_merge(paths_dict[clean_path], methods)
+    return paths_dict
+```
+
+Vendor is a plain argument (not read from the `VENDOR_MEDIA_TYPE` global inside),
+so the function is pure with respect to global state and tests pass any vendor
+string. The in-place payload mutation is kept — it is behavior-preserving and
+invisible to callers that build a fresh schema each time.
+
+### 2. `_custom_openapi` calls it
+
+The tail of `_custom_openapi` collapses to:
+
+```python
+    self.openapi_schema["paths"] = _collapse_versioned_paths(
+        self.openapi_schema["paths"],
+        versioned_paths,
+        _get_vendor_media_type(),
+    )
+    return self.openapi_schema
+```
+
+The local `vendor_media_type`, `paths_dict`, `raw_path`, `methods` variables and the
+inline loop are removed; the explanatory comment moves into the function docstring.
+
+### Rejected alternative
+
+A dedicated `fast_version/openapi.py` owning both `_iter_openapi_routes` and
+`_collapse_versioned_paths` was considered (symmetry with `accept.py`). Rejected as
+YAGNI: `app.py` is ~127 lines with no size pressure, and relocating the working,
+already-tested `_iter_openapi_routes` would churn its test import for a cohesion gain
+that isn't paying rent. If `app.py` later grows, promoting both is a clean follow-up.
+
+## Testing
+
+Four unit tests in `tests/test_app.py` (beside the `_iter_openapi_routes` test),
+calling `_collapse_versioned_paths` directly with fixture path-dicts — one per
+branch:
+
+1. Non-versioned path → passed through unchanged.
+2. Versioned path with `requestBody` → content key rewritten to `{vendor};
+   version=X.Y`, path un-suffixed.
+3. Two versions of one path → merged onto the clean path (both media-type keys).
+4. Versioned path without `requestBody` → collapsed, no content rewrite.
+
+Pure addition — every existing OpenAPI integration test stays (they own
+"the schema is correct through the real pipeline"; the unit tests own "the collapse
+transform is correct at its seam"). `just test-ci` stays at 100% coverage;
+`just lint-ci` clean.
+
+## Risk
+
+- **Coverage regression (low).** The four unit tests plus the retained integration
+  tests cover every branch of the function. Mitigation: `just test-ci` before push.
+- **Accidental behavior drift (low).** The loop moves verbatim; the only structural
+  change is `return paths_dict` instead of assigning `self.openapi_schema["paths"]`
+  inline. Mitigation: the existing integration tests (distinct-models, prefix,
+  colon-preservation) exercise the real pipeline unchanged.

--- a/planning/changes/2026-07-04.03-collapse-versioned-paths-seam/plan.md
+++ b/planning/changes/2026-07-04.03-collapse-versioned-paths-seam/plan.md
@@ -40,16 +40,19 @@ preserving behavior.
   In `tests/test_app.py`, add `_collapse_versioned_paths` to the existing
   `from fast_version.app import ...` line (currently imports `_iter_openapi_routes`),
   and append these four tests. `VERSION_HEADER` is already imported from
-  `tests.conftest`.
+  `tests.conftest`. Note: `test_app.py` has a module-level
+  `pytestmark = [pytest.mark.asyncio]`, so every test in it is `async def`
+  (even sync-logic ones like `test_iter_openapi_routes_...`); a plain `def`
+  test emits a `PytestWarning`. Write these as `async def` to match.
 
   ```python
-  def test_collapse_versioned_paths_passes_through_non_versioned() -> None:
+  async def test_collapse_versioned_paths_passes_through_non_versioned() -> None:
       raw = {"/simple/": {"get": {"responses": {"200": {"description": "ok"}}}}}
       result = _collapse_versioned_paths(raw, set(), VERSION_HEADER)
       assert result == {"/simple/": {"get": {"responses": {"200": {"description": "ok"}}}}}
 
 
-  def test_collapse_versioned_paths_rewrites_request_body_content_key() -> None:
+  async def test_collapse_versioned_paths_rewrites_request_body_content_key() -> None:
       raw = {
           "/test/:1.0": {
               "post": {"requestBody": {"content": {"application/json": {"schema": {"x": 1}}}}},
@@ -62,7 +65,7 @@ preserving behavior.
       assert content[f"{VERSION_HEADER}; version=1.0"] == {"schema": {"x": 1}}
 
 
-  def test_collapse_versioned_paths_merges_two_versions_of_same_path() -> None:
+  async def test_collapse_versioned_paths_merges_two_versions_of_same_path() -> None:
       raw = {
           "/test/:1.0": {"post": {"requestBody": {"content": {"application/json": {"schema": {"v": 1}}}}}},
           "/test/:2.0": {"post": {"requestBody": {"content": {"application/json": {"schema": {"v": 2}}}}}},
@@ -73,7 +76,7 @@ preserving behavior.
       assert set(content) == {f"{VERSION_HEADER}; version=1.0", f"{VERSION_HEADER}; version=2.0"}
 
 
-  def test_collapse_versioned_paths_versioned_without_request_body() -> None:
+  async def test_collapse_versioned_paths_versioned_without_request_body() -> None:
       raw = {"/test/:1.0": {"get": {"responses": {"200": {"description": "ok"}}}}}
       result = _collapse_versioned_paths(raw, {"/test/:1.0"}, VERSION_HEADER)
       assert set(result) == {"/test/"}

--- a/planning/changes/2026-07-04.03-collapse-versioned-paths-seam/plan.md
+++ b/planning/changes/2026-07-04.03-collapse-versioned-paths-seam/plan.md
@@ -1,0 +1,196 @@
+# collapse-versioned-paths-seam — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lift the OpenAPI path-collapse loop out of `_custom_openapi` into a
+pure `_collapse_versioned_paths` function, unit-testable at its own seam,
+preserving behavior.
+
+**Spec:** [`design.md`](./design.md)
+
+**Branch:** `refactor/collapse-versioned-paths-seam`
+
+**Commit strategy:** Per-task commits.
+
+## Global constraints
+
+- Python 3.10-3.14. Ruff `select = ["ALL"]`, line length 120, and `ty` must
+  pass (`just lint` to auto-fix, `just lint-ci` to check).
+- `ty: ignore` not `type: ignore`. Imports at module level; annotate all args.
+- Coverage gate: `just test-ci` runs `--cov-fail-under=100`. Every commit stays
+  green at 100%.
+- Behavior-preserving: the generated OpenAPI schema is byte-identical.
+
+---
+
+### Task 1: Extract `_collapse_versioned_paths` (TDD)
+
+**Files:**
+- Modify: `fast_version/app.py` (add function; slim `_custom_openapi`)
+- Modify: `tests/test_app.py` (add import + 4 unit tests)
+
+**Interfaces produced:**
+- `fast_version.app._collapse_versioned_paths(raw_paths: dict[str, typing.Any], versioned_paths: set[str], vendor_media_type: str) -> dict[str, typing.Any]`
+
+- [ ] **Step 1: Write the failing unit tests**
+
+  In `tests/test_app.py`, add `_collapse_versioned_paths` to the existing
+  `from fast_version.app import ...` line (currently imports `_iter_openapi_routes`),
+  and append these four tests. `VERSION_HEADER` is already imported from
+  `tests.conftest`.
+
+  ```python
+  def test_collapse_versioned_paths_passes_through_non_versioned() -> None:
+      raw = {"/simple/": {"get": {"responses": {"200": {"description": "ok"}}}}}
+      result = _collapse_versioned_paths(raw, set(), VERSION_HEADER)
+      assert result == {"/simple/": {"get": {"responses": {"200": {"description": "ok"}}}}}
+
+
+  def test_collapse_versioned_paths_rewrites_request_body_content_key() -> None:
+      raw = {
+          "/test/:1.0": {
+              "post": {"requestBody": {"content": {"application/json": {"schema": {"x": 1}}}}},
+          },
+      }
+      result = _collapse_versioned_paths(raw, {"/test/:1.0"}, VERSION_HEADER)
+      assert set(result) == {"/test/"}
+      content = result["/test/"]["post"]["requestBody"]["content"]
+      assert set(content) == {f"{VERSION_HEADER}; version=1.0"}
+      assert content[f"{VERSION_HEADER}; version=1.0"] == {"schema": {"x": 1}}
+
+
+  def test_collapse_versioned_paths_merges_two_versions_of_same_path() -> None:
+      raw = {
+          "/test/:1.0": {"post": {"requestBody": {"content": {"application/json": {"schema": {"v": 1}}}}}},
+          "/test/:2.0": {"post": {"requestBody": {"content": {"application/json": {"schema": {"v": 2}}}}}},
+      }
+      result = _collapse_versioned_paths(raw, {"/test/:1.0", "/test/:2.0"}, VERSION_HEADER)
+      assert set(result) == {"/test/"}
+      content = result["/test/"]["post"]["requestBody"]["content"]
+      assert set(content) == {f"{VERSION_HEADER}; version=1.0", f"{VERSION_HEADER}; version=2.0"}
+
+
+  def test_collapse_versioned_paths_versioned_without_request_body() -> None:
+      raw = {"/test/:1.0": {"get": {"responses": {"200": {"description": "ok"}}}}}
+      result = _collapse_versioned_paths(raw, {"/test/:1.0"}, VERSION_HEADER)
+      assert set(result) == {"/test/"}
+      assert result["/test/"] == {"get": {"responses": {"200": {"description": "ok"}}}}
+  ```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+  Run: `uv run --no-sync pytest tests/test_app.py -k collapse_versioned_paths -q`
+  Expected: FAIL — `ImportError: cannot import name '_collapse_versioned_paths'`.
+
+- [ ] **Step 3: Add the function to `app.py`**
+
+  In `fast_version/app.py`, add this module-level function (place it directly
+  above `_custom_openapi`):
+
+  ```python
+  def _collapse_versioned_paths(
+      raw_paths: dict[str, typing.Any],
+      versioned_paths: set[str],
+      vendor_media_type: str,
+  ) -> dict[str, typing.Any]:
+      """Collapse the per-version ``:<version>`` suffixed paths back onto their real path.
+
+      Only request bodies are versioned (keyed by media type); operation-level fields
+      (parameters, summary, tags, ...) come from the first-merged version, so versions
+      of the same path+method should differ only in body schema.
+      """
+      paths_dict: dict[str, typing.Any] = {}
+      for raw_path, methods in raw_paths.items():
+          if raw_path not in versioned_paths:
+              paths_dict[raw_path] = methods
+              continue
+          clean_path, version_str = raw_path.rsplit(":", 1)
+          for payload in methods.values():
+              if "requestBody" not in payload:
+                  continue
+              payload["requestBody"]["content"] = {
+                  f"{vendor_media_type}; version={version_str}": content
+                  for content in payload["requestBody"]["content"].values()
+              }
+          if clean_path not in paths_dict:
+              paths_dict[clean_path] = methods
+              continue
+          helpers.dict_merge(paths_dict[clean_path], methods)
+      return paths_dict
+  ```
+
+- [ ] **Step 4: Slim `_custom_openapi` to call it**
+
+  In `fast_version/app.py`, replace the tail of `_custom_openapi` — the block
+  from the comment `# Collapse the per-version paths back onto their real path.`
+  through `self.openapi_schema["paths"] = paths_dict` (currently lines 101-125)
+  — with:
+
+  ```python
+      self.openapi_schema["paths"] = _collapse_versioned_paths(
+          self.openapi_schema["paths"],
+          versioned_paths,
+          _get_vendor_media_type(),
+      )
+      return self.openapi_schema
+  ```
+
+  Remove the now-unused local declarations (`vendor_media_type = ...`,
+  `paths_dict`, `raw_path: str`, `methods: dict[str, typing.Any]`). Keep the
+  `if self.openapi_schema:` guard and the `get_openapi(...)` call above unchanged.
+
+- [ ] **Step 5: Run the unit tests to verify they pass**
+
+  Run: `uv run --no-sync pytest tests/test_app.py -k collapse_versioned_paths -q`
+  Expected: PASS (4 passed).
+
+- [ ] **Step 6: Full gate**
+
+  Run: `just test-ci` — expected 100% coverage, all tests pass (existing OpenAPI
+  integration tests still green).
+  Run: `just lint` then `just lint-ci` — ruff + ty clean.
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add fast_version/app.py tests/test_app.py
+  git commit -m "refactor: extract _collapse_versioned_paths from _custom_openapi"
+  ```
+
+---
+
+### Task 2: Finalize the planning bundle
+
+**Files:**
+- Modify: `planning/changes/2026-07-04.03-collapse-versioned-paths-seam/design.md`
+
+Behavior-preserving, so no `architecture/<capability>.md` promotion is required.
+
+- [ ] **Step 1: Finalize the design summary**
+
+  In the bundle's `design.md`, update the `summary:` frontmatter to the realized
+  result (add the PR number once known, e.g. `... (shipped in #NN)`):
+  `Extracted the OpenAPI path-collapse loop into pure _collapse_versioned_paths, unit-tested at its own seam beside _iter_openapi_routes; behavior unchanged.`
+
+- [ ] **Step 2: Validate + full gate**
+
+  Run: `just check-planning` — expected `planning: OK`.
+  Run: `just lint-ci` and `just test-ci` — clean, 100%.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add planning/changes/2026-07-04.03-collapse-versioned-paths-seam/design.md
+  git commit -m "docs(planning): finalize collapse-versioned-paths-seam summary"
+  ```
+
+---
+
+## Finish
+
+Push the branch and open a PR (never local-merge). Watch PR CI across Python
+3.10-3.14. After merge: `git pull --ff-only` on `main`, delete the local branch,
+`git remote prune origin`.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,7 +7,7 @@ from starlette import status
 from starlette.testclient import TestClient
 
 from fast_version import init_fastapi_versioning
-from fast_version.app import _iter_openapi_routes
+from fast_version.app import _collapse_versioned_paths, _iter_openapi_routes
 from fast_version.router import VersionedAPIRoute, VersionedAPIRouter
 from tests.conftest import DOCS_URL_PREFIX, VERSION_HEADER, VERSIONED_ROUTER_OBJ
 
@@ -223,3 +223,40 @@ async def test_openapi_schema_preserves_non_versioned_path_with_colon() -> None:
 
     response = client.post("/resource:activate", json={"value": "x"})
     assert response.status_code == status.HTTP_200_OK
+
+
+async def test_collapse_versioned_paths_passes_through_non_versioned() -> None:
+    raw = {"/simple/": {"get": {"responses": {"200": {"description": "ok"}}}}}
+    result = _collapse_versioned_paths(raw, set(), VERSION_HEADER)
+    assert result == {"/simple/": {"get": {"responses": {"200": {"description": "ok"}}}}}
+
+
+async def test_collapse_versioned_paths_rewrites_request_body_content_key() -> None:
+    raw = {
+        "/test/:1.0": {
+            "post": {"requestBody": {"content": {"application/json": {"schema": {"x": 1}}}}},
+        },
+    }
+    result = _collapse_versioned_paths(raw, {"/test/:1.0"}, VERSION_HEADER)
+    assert set(result) == {"/test/"}
+    content = result["/test/"]["post"]["requestBody"]["content"]
+    assert set(content) == {f"{VERSION_HEADER}; version=1.0"}
+    assert content[f"{VERSION_HEADER}; version=1.0"] == {"schema": {"x": 1}}
+
+
+async def test_collapse_versioned_paths_merges_two_versions_of_same_path() -> None:
+    raw = {
+        "/test/:1.0": {"post": {"requestBody": {"content": {"application/json": {"schema": {"v": 1}}}}}},
+        "/test/:2.0": {"post": {"requestBody": {"content": {"application/json": {"schema": {"v": 2}}}}}},
+    }
+    result = _collapse_versioned_paths(raw, {"/test/:1.0", "/test/:2.0"}, VERSION_HEADER)
+    assert set(result) == {"/test/"}
+    content = result["/test/"]["post"]["requestBody"]["content"]
+    assert set(content) == {f"{VERSION_HEADER}; version=1.0", f"{VERSION_HEADER}; version=2.0"}
+
+
+async def test_collapse_versioned_paths_versioned_without_request_body() -> None:
+    raw = {"/test/:1.0": {"get": {"responses": {"200": {"description": "ok"}}}}}
+    result = _collapse_versioned_paths(raw, {"/test/:1.0"}, VERSION_HEADER)
+    assert set(result) == {"/test/"}
+    assert result["/test/"] == {"get": {"responses": {"200": {"description": "ok"}}}}


### PR DESCRIPTION
## What

Behavior-preserving refactor from fresh architecture review #2 (candidate A). Lifts the OpenAPI path-collapse/content-rewrite loop out of the monkey-patched `_custom_openapi` into a pure module-level function:

```python
_collapse_versioned_paths(raw_paths, versioned_paths, vendor_media_type) -> dict[str, typing.Any]
```

It splits the `:<version>` suffix, rewrites each `requestBody` content key to `{vendor}; version=X.Y`, and merges same-path versions via `helpers.dict_merge`. `_custom_openapi` now calls it.

## Why

`_iter_openapi_routes` — the first half of the OpenAPI-versioning transform — was already a seam-testable function with a direct unit test. The collapse loop, its second half, was inline and reachable only by building an app and fetching `/openapi.json`. This completes the pattern: the collapse rules (colon split, content-key rewrite, per-version merge) are now verifiable without an ASGI round-trip. Vendor is a plain argument, so the function is pure w.r.t. the `VENDOR_MEDIA_TYPE` global.

A dedicated `openapi.py` module (symmetry with `accept.py`) was considered and rejected as YAGNI — `app.py` is ~130 lines with no size pressure. Recorded in the design doc.

## Tests

Four `async def` unit tests in `tests/test_app.py` beside the `_iter_openapi_routes` test, one per branch: non-versioned passthrough, requestBody rewrite, two-version `dict_merge`, versioned-without-requestBody. Pure addition — the existing OpenAPI integration tests (distinct-models, prefix, colon-preservation) are unchanged and still exercise the real pipeline.

- `just test-ci` — 36 passed, coverage 100%.
- `just lint-ci` — ruff + ty clean, `planning: OK`.

Planning bundle: `planning/changes/2026-07-04.03-collapse-versioned-paths-seam/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)