### PR TITLE
docs: 1.4.7 release notes, vendor-global decision, architecture pages

### DIFF
--- a/architecture/accept-header-version-negotiation.md
+++ b/architecture/accept-header-version-negotiation.md
@@ -1,0 +1,66 @@
+# Accept-header version negotiation
+
+How a client selects a route version, and how the library resolves and serves
+it. A client sends `Accept: <vendor-media-type>; version=<major>.<minor>` (e.g.
+`application/vnd.some.name+json; version=2.0`); the library routes to the
+matching versioned route and stamps the response `content-type` with the
+resolved version.
+
+Three layers cooperate through the ASGI `scope["version"]` key: **parse** (the
+middleware), **match** (the route), **respond** (the response class).
+
+## Parse — `fast_version/accept.py`
+
+`FastAPIVersioningMiddleware` extracts the `Accept` header (lowercased, stripped
+by `get_accept_header_from_scope`) and calls the pure
+`parse_accept_version(accept_header, vendor_media_type)`, which returns a sealed
+result:
+
+- **`Ignore`** — the request selects no version, so the middleware leaves
+  `scope["version"]` unset and the default applies downstream. Produced for an
+  empty or `*/*` header, a header that does not split into exactly one `;`, or a
+  media type that is not the vendor media type. Media-type comparison is
+  case-insensitive (the vendor is lowercased to match the already-lowercased
+  header — RFC 9110 §8.3.1, RFC 6838 §4.2).
+- **`ParsedVersion((major, minor))`** — a valid `version=X.Y`. The middleware
+  writes the tuple into `scope["version"]`.
+- **`ParseError(detail)`** — the middleware returns a 400 with that detail. Two
+  cases: a missing or misnamed version key → `"No version in Accept header"`; a
+  value that fails `^\d\.\d$` → `"Version should be in <major>.<minor> format"`.
+
+The parse is pure and holds all string-level rules; the middleware keeps only the
+ASGI concerns (the `scope["type"] == "http"` guard, header extraction, and
+mapping the result onto `scope`/a 400 response).
+
+## Match — `fast_version/router.py`
+
+Each versioned route is a `VersionedAPIRoute`. Starlette calls `matches` on every
+route; the override returns `Match.FULL` only when the request's resolved version
+(`scope.get("version", accept.DEFAULT_VERSION)`) equals the route's own version,
+and `Match.NONE` otherwise. So several routes can share a path and method,
+distinguished only by version; a request whose version matches none of them
+yields 405.
+
+A route's version lives as a `version` attribute on the endpoint function.
+`VersionedAPIRouter.api_route` defaults it to `DEFAULT_VERSION` when absent, and
+the `set_api_version((major, minor))` decorator overrides it. (Version is carried
+on the function rather than passed as a route keyword — a deliberate choice
+constrained by FastAPI's closed verb-method signatures; see
+`planning/decisions/2026-07-04-version-stays-a-function-decorator.md`.)
+
+## Respond — `fast_version/router.py`
+
+Each versioned route gets a per-route `VersionedJSONResponse` whose `media_type`
+resolves to `<vendor>; version=<major>.<minor>`, so the response `content-type`
+carries the served version. The vendor part is read lazily at access time via the
+`ClassProperty` descriptor, which decouples when the vendor is configured from
+when routes are registered (see
+`planning/decisions/2026-07-04-classproperty-stays-for-ordering-independence.md`).
+
+## Configuration
+
+`init_fastapi_versioning(app=, vendor_media_type=)` wires the three layers: it
+sets the class-level `VENDOR_MEDIA_TYPE`, adds the middleware, and swaps in the
+custom OpenAPI generator. The vendor media type is process-global class state —
+one vendor per process (see
+`planning/decisions/2026-07-04-vendor-media-type-stays-process-global.md`).

--- a/architecture/glossary.md
+++ b/architecture/glossary.md
@@ -1,0 +1,37 @@
+# Glossary
+
+The project's ubiquitous language — the domain terms that code, specs, and
+capability pages share. Living prose, no frontmatter, dated by git.
+
+**Vendor media type**:
+The base media type a deployment configures to signal versioned requests, e.g.
+`application/vnd.some.name+json`. Passed once to `init_fastapi_versioning` and
+matched case-insensitively against the request's `Accept` media type.
+_Avoid_: content type (too generic), MIME type
+
+**Version**:
+A `(major, minor)` pair identifying one API version, each a single digit
+(`0`-`9`). Written `major.minor` on the wire (`version=2.0`).
+_Avoid_: revision, API level
+
+**Default version**:
+`(1, 0)` — the version a request resolves to when it selects none (no `Accept`
+header, a non-vendor media type, or a vendor media type with no `version`
+parameter). Owned by `accept.DEFAULT_VERSION`.
+
+**Versioned route**:
+A route registered through `VersionedAPIRouter`, carrying its own version.
+Several versioned routes may share the same path and method, differing only by
+version; the router selects among them by the request's resolved version.
+_Avoid_: endpoint (reserve for the handler function)
+
+**Accept-header negotiation**:
+Resolving which versioned route serves a request from its `Accept` header. Spans
+three cooperating layers — parse, match, respond — joined by the ASGI
+`scope["version"]` key.
+_Avoid_: content negotiation (broader HTTP concept)
+
+**Resolved version**:
+The `(major, minor)` written into `scope["version"]` by the middleware after a
+successful parse, or the default when the middleware leaves it unset. What
+route matching compares against.

--- a/architecture/openapi-schema-versioning.md
+++ b/architecture/openapi-schema-versioning.md
@@ -1,0 +1,44 @@
+# OpenAPI schema versioning
+
+How the generated OpenAPI schema represents several versions that share one path.
+Because multiple versioned routes have the same path and method, a naive
+`get_openapi` call would merge them and lose the per-version request bodies. The
+library replaces `app.openapi` with a custom generator that keeps the versions
+distinct and then collapses them back under the clean path, keyed by media type.
+
+Implemented in `fast_version/app.py`, installed by `init_fastapi_versioning`
+(`app.openapi = MethodType(_custom_openapi, app)`).
+
+## Build a disambiguated route list — `_iter_openapi_routes`
+
+Traverses the app's routes (descending into included routers) and returns a route
+list for a single `get_openapi` call, plus the set of paths it made distinct.
+Non-versioned routes pass through unchanged. Each versioned route is
+shallow-copied with its `path_format` suffixed by `:<version>`, so `get_openapi`
+treats same-path versions as separate paths within one call — a single call is
+required so FastAPI disambiguates same-named-but-different Pydantic models across
+versions.
+
+The function returns the exact set of suffixed paths, so downstream
+post-processing matches versioned paths by identity rather than by sniffing for a
+colon (a non-versioned path may legitimately contain one, e.g. `/x:action`).
+
+## Collapse back onto the real path — `_collapse_versioned_paths`
+
+A pure `(raw_paths, versioned_paths, vendor_media_type) -> paths` transform.
+Non-versioned paths pass through. For each suffixed path it splits off the
+`:<version>`, rewrites every operation's `requestBody` content key to
+`<vendor>; version=<major>.<minor>`, and merges the per-version operations back
+under the clean path via `helpers.dict_merge`. Operation-level fields
+(parameters, summary, tags) come from the first-merged version, so versions of
+one path+method should differ only in body schema.
+
+Only **request** bodies are rewritten here. Response content-type versioning comes
+from each route's `VersionedJSONResponse.media_type` (see
+[accept-header-version-negotiation.md](accept-header-version-negotiation.md)),
+which `get_openapi` reads directly — so the response side needs no rewrite.
+
+## Caching
+
+`_custom_openapi` caches its result in `app.openapi_schema` and returns the cached
+value on later calls, matching FastAPI's own generate-once behavior.

--- a/planning/decisions/2026-07-04-vendor-media-type-stays-process-global.md
+++ b/planning/decisions/2026-07-04-vendor-media-type-stays-process-global.md
@@ -1,0 +1,54 @@
+---
+status: accepted
+summary: VENDOR_MEDIA_TYPE stays a process-global class attribute on VersionedAPIRouter; instance-scoping it collides with the per-route response-class mechanism and one vendor per process is an accepted constraint.
+supersedes: null
+superseded_by: null
+---
+
+# Vendor media type stays process-global class state
+
+**Decision:** Keep the vendor media type as a mutable class attribute
+(`VersionedAPIRouter.VENDOR_MEDIA_TYPE`), set once by
+`init_fastapi_versioning`. Do **not** rework it into per-app / per-router
+instance state.
+
+## Context
+
+Architecture review #2 (candidate B) flagged the vendor as process-global class
+state: `VENDOR_MEDIA_TYPE` is a mutable class attribute read by three call sites
+(the middleware, `_get_vendor_media_type`, and the response `ClassProperty`).
+The consequences are real but mild — two FastAPI apps in one process cannot hold
+different vendors, and the test suite relies on serial execution not to bleed the
+global between apps. The proposed deepening was to make the vendor instance state
+owned by the app/router that configured it.
+
+## Decision & rationale
+
+Rejected; the class-global stays. Two reasons:
+
+- **It collides with a mechanism already decided.** The per-route response class
+  reaches the vendor precisely *because* it is a class-level global it can read
+  lazily (see the ClassProperty decision,
+  `decisions/2026-07-04-classproperty-stays-for-ordering-independence.md`). A
+  per-route `VersionedJSONResponse` subclass has no handle on its app or router
+  instance, so instance-scoping the vendor would require re-plumbing exactly the
+  response-content-type path that decision deliberately left alone.
+- **One vendor per process is an accepted, documented constraint.** It is called
+  out in `CLAUDE.md` ("effectively one vendor media type per process"). The
+  library's public surface (`init_fastapi_versioning(app=, vendor_media_type=)`)
+  reads as app-scoped, but the single-process-single-vendor reality has not
+  caused friction, and no user has needed multi-vendor-per-process.
+
+The global's cost (test-ordering fragility, one vendor per process) does not
+justify re-plumbing a mechanism that is working and separately decided.
+
+## Revisit trigger
+
+Reopen if either changes:
+
+- A concrete need arises to run two versioned apps with **different** vendor
+  media types in the **same process** (e.g. mounting two independently-versioned
+  APIs), making per-app vendor ownership load-bearing.
+- The per-route response-class mechanism is reworked for another reason (its own
+  revisit triggers are in the ClassProperty decision), at which point threading
+  the vendor as instance state may become cheap.

--- a/planning/releases/1.4.7.md
+++ b/planning/releases/1.4.7.md
@@ -1,0 +1,39 @@
+# fast-version 1.4.7 — case-insensitive vendor matching
+
+A bug-fix release. Accept-header vendor media types are now matched
+case-insensitively, so a mixed-case configured vendor works as expected. The
+rest of the release is internal refactoring with no behavior change.
+
+## Fix
+
+- **Case-insensitive vendor media type.** The request media type was compared
+  against the configured `vendor_media_type` as-is, but the request side is
+  lowercased on the way in — so a mixed-case vendor (e.g.
+  `application/vnd.Some.Name+json`) never matched and requests silently fell
+  back to the default v1.0. Matching is now case-insensitive, per RFC 9110
+  §8.3.1 and RFC 6838 §4.2. The response `content-type` still echoes the exact
+  casing you configured. (#18)
+
+## Internal refactors
+
+- **Accept-header parsing extracted into `accept.py`.** The parse moved out of
+  the ASGI middleware into a pure `parse_accept_version` behind a sealed result
+  (`Ignore | ParsedVersion | ParseError`), testable at its own seam. The version
+  regex, default, and header extraction now live in one module. No behavior
+  change. (#17)
+- **OpenAPI path-collapse extracted into a pure function.** The schema
+  post-processing that collapses per-version paths and rewrites request-body
+  media-type keys is now `_collapse_versioned_paths`, unit-tested directly. No
+  behavior change. (#21)
+
+## Downstream
+
+No action needed — the only behavior change is the bug fix, which makes a
+previously-broken configuration (mixed-case vendor) start working. No API
+changes.
+
+## Internals
+
+- Test suite at 100% coverage across Python 3.10-3.14. Two design decisions
+  recorded under `planning/decisions/` (version stays a function decorator;
+  `ClassProperty` stays for ordering-independence).


### PR DESCRIPTION
Documentation close-out after the two architecture reviews. No code changes.

## 1. Release notes — `planning/releases/1.4.7.md`

Drafts 1.4.7 (patch). Headline: the case-insensitive vendor matching **fix** (#18) — a mixed-case configured vendor previously never matched and silently fell back to v1.0. Also lists the internal refactors (#17, #21). No API changes, so downstream needs no action. **The tag/publish is yours to cut** — this only stages the note (versioning is tag-driven).

## 2. Decision — `planning/decisions/2026-07-04-vendor-media-type-stays-process-global.md`

Records review #2's candidate B (vendor as process-global class state) as **rejected**, closing that review's loop so it isn't re-suggested. Rationale: instance-scoping collides with the response-class mechanism kept by the ClassProperty decision, and one-vendor-per-process is an accepted, documented constraint. Includes a revisit trigger (needing two different vendors in one process).

## 3. Architecture pages — `architecture/`

Seeds the living-truth home, which until now held only its README:

- `glossary.md` — the ubiquitous language (Vendor media type, Version, Versioned route, …).
- `accept-header-version-negotiation.md` — the parse → match → respond flow across `accept.py` / `router.py`.
- `openapi-schema-versioning.md` — `_iter_openapi_routes` + `_collapse_versioned_paths` and why only request bodies are rewritten.

Both pages cross-reference the three decision records for the deliberate constraints.

`just check-planning` → `planning: OK`; `just lint-ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)